### PR TITLE
Go back to repeating textures by shader

### DIFF
--- a/assets/shaders/repeated.wgsl
+++ b/assets/shaders/repeated.wgsl
@@ -1,0 +1,85 @@
+// Same imports as <https://github.com/bevyengine/bevy/blob/main/crates/bevy_pbr/src/render/pbr.wgsl>
+#import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::pbr_bindings
+#import bevy_pbr::mesh_bindings
+
+#import bevy_pbr::utils
+#import bevy_pbr::clustered_forward
+#import bevy_pbr::lighting
+#import bevy_pbr::shadows
+#import bevy_pbr::pbr_functions
+
+struct Repeats {
+    horizontal: u32,
+    vertical: u32,
+}
+
+@group(1) @binding(0)
+var texture: texture_2d<f32>;
+@group(1) @binding(1)
+var texture_sampler: sampler;
+@group(1) @binding(2)
+var<uniform> repeats: Repeats;
+
+struct FragmentInput {
+    @builtin(front_facing) is_front: bool,
+    @builtin(position) frag_coord: vec4<f32>,
+    #import bevy_pbr::mesh_vertex_output
+}
+
+
+fn get_texture_sample(coords: vec2<f32>) -> vec3<f32> {
+    let repeated_coords = vec2<f32>(
+        (coords.x % (1. / f32(repeats.horizontal))) * f32(repeats.horizontal),
+        (coords.y % (1. / f32(repeats.vertical))) * f32(repeats.vertical)
+    );
+    return textureSample(texture, texture_sampler, repeated_coords).rgb;
+}
+
+/// Adapted from <https://github.com/bevyengine/bevy/blob/main/crates/bevy_pbr/src/render/pbr.wgsl#L30>
+fn get_pbr_output(in: FragmentInput) -> vec4<f32> {
+    var material = standard_material_new();
+    material.perceptual_roughness = 1.0;
+
+    var pbr_input = pbr_input_new();
+    pbr_input.frag_coord = in.frag_coord;
+    pbr_input.world_position = in.world_position;
+    pbr_input.world_normal = in.world_normal;
+    pbr_input.material = material;
+    pbr_input.world_normal = prepare_world_normal(
+        in.world_normal,
+        (material.flags & STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT) != 0u,
+        in.is_front,
+    );
+
+    pbr_input.is_orthographic = view.projection[3].w == 1.0;
+
+    pbr_input.N = apply_normal_mapping(
+        material.flags,
+        pbr_input.world_normal,
+        in.uv,
+    );
+    pbr_input.V = calculate_view(in.world_position, pbr_input.is_orthographic);
+
+    var output_color = pbr(pbr_input);
+
+    output_color = tone_mapping(output_color);
+    var output_rgb = output_color.rgb;
+    output_rgb = pow(output_rgb, vec3<f32>(1.0 / 2.2));
+    output_rgb = output_rgb + screen_space_dither(in.frag_coord.xy);
+    // This conversion back to linear space is required because our output texture format is
+    // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
+    output_rgb = pow(output_rgb, vec3<f32>(2.2));
+    output_color = vec4(output_rgb, output_color.a);
+
+    return output_color;
+}
+
+@fragment
+fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
+    let texture = get_texture_sample(in.uv);
+    let pbr_output = get_pbr_output(in);
+
+
+    return vec4(texture, 0.) * pbr_output;
+}

--- a/src/level_instanciation/spawning/post_spawn_modification.rs
+++ b/src/level_instanciation/spawning/post_spawn_modification.rs
@@ -90,9 +90,3 @@ pub fn set_texture_to_repeat(
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-pub struct Repeats {
-    pub horizontal: u32,
-    pub vertical: u32,
-}

--- a/src/level_instanciation/spawning/post_spawn_modification.rs
+++ b/src/level_instanciation/spawning/post_spawn_modification.rs
@@ -72,12 +72,12 @@ pub fn set_texture_to_repeat(
                     let standard_material =
                         standard_materials.get(standard_material_handle).unwrap();
                     let texture = standard_material.base_color_texture.as_ref().unwrap();
-                    let key = (texture.id(), repeats.clone());
+                    let key = (texture.id(), repeats);
 
                     let repeated_material = materials.repeated.entry(key).or_insert_with(|| {
                         repeated_materials.add(RepeatedMaterial {
                             texture: Some(texture.clone()),
-                            repeats: repeats.clone(),
+                            repeats,
                         })
                     });
 

--- a/src/level_instanciation/spawning/post_spawn_modification.rs
+++ b/src/level_instanciation/spawning/post_spawn_modification.rs
@@ -1,7 +1,7 @@
 use crate::level_instanciation::spawning::spawn::Despawn;
+use crate::shader::{Materials, RepeatedMaterial, Repeats};
 use crate::util::trait_extension::MeshExt;
 use bevy::prelude::*;
-use bevy::render::mesh::VertexAttributeValues;
 use bevy_rapier3d::prelude::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -53,9 +53,12 @@ pub fn despawn_removed(
 }
 
 pub fn set_texture_to_repeat(
+    mut commands: Commands,
     added_name: Query<(&Name, &Children), Added<Name>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mesh_handles: Query<&Handle<Mesh>>,
+    material_handles: Query<&Handle<StandardMaterial>>,
+    mut materials: ResMut<Materials>,
+    standard_materials: Res<Assets<StandardMaterial>>,
+    mut repeated_materials: ResMut<Assets<RepeatedMaterial>>,
 ) {
     let re = Regex::new(r"\[repeat:(\d+),(\d+)\]").unwrap();
     for (name, children) in &added_name {
@@ -64,18 +67,24 @@ pub fn set_texture_to_repeat(
                 horizontal: captures[1].parse().unwrap(),
                 vertical: captures[2].parse().unwrap(),
             };
-            for mesh_handle in children
-                .iter()
-                .filter_map(|entity| mesh_handles.get(*entity).ok())
-            {
-                let collider_mesh = meshes.get_mut(mesh_handle).unwrap();
-                let uvs = match collider_mesh.attribute_mut(Mesh::ATTRIBUTE_UV_0).unwrap() {
-                    VertexAttributeValues::Float32x2(values) => values,
-                    _ => panic!("Unexpected vertex attribute type"),
-                };
-                for uv in uvs.iter_mut() {
-                    uv[0] *= repeats.horizontal as f32;
-                    uv[1] *= repeats.vertical as f32;
+            for child in children.iter() {
+                if let Ok(standard_material_handle) = material_handles.get(*child) {
+                    let standard_material =
+                        standard_materials.get(standard_material_handle).unwrap();
+                    let texture = standard_material.base_color_texture.as_ref().unwrap();
+                    let key = (texture.id(), repeats.clone());
+
+                    let repeated_material = materials.repeated.entry(key).or_insert_with(|| {
+                        repeated_materials.add(RepeatedMaterial {
+                            texture: Some(texture.clone()),
+                            repeats: repeats.clone(),
+                        })
+                    });
+
+                    commands
+                        .entity(*child)
+                        .remove::<Handle<StandardMaterial>>()
+                        .insert(repeated_material.clone());
                 }
             }
         }


### PR DESCRIPTION
- Fix #114 
The alternative would have been to keep a map from desired repeats to modified meshes, but keeping copies of entire meshes is way more expensive than keeping copies of materials.