### PR TITLE
Use rapier branch with less jitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,7 +875,7 @@ checksum = "8ec44f7655039546bc5d34d98de877083473f3e9b2b81d560c528d6d74d3eff4"
 [[package]]
 name = "bevy_rapier3d"
 version = "0.20.0"
-source = "git+https://github.com/janhohenheim/bevy_rapier?branch=own-fork#5a49c28384e5512cf9128acdd4e0e3254e50e967"
+source = "git+https://github.com/janhohenheim/bevy_rapier?branch=own-fork#3f773e3219fc2320f4827c86fb83bbc7462f353c"
 dependencies = [
  "bevy",
  "bitflags",
@@ -1918,14 +1918,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3210,9 +3210,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -3330,7 +3330,7 @@ checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 [[package]]
 name = "rapier3d"
 version = "0.17.1"
-source = "git+https://github.com/janhohenheim/rapier?branch=experiment#ae9d6b9c9e536997b9c2ee314e55eb3afec70ceb"
+source = "git+https://github.com/janhohenheim/rapier?branch=fix-kcc#dd195a47203ec4d9540f1a656ac53859372d353f"
 dependencies = [
  "approx",
  "arrayvec",
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3935,10 +3935,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "d805f96b7e61fce8728f142e213a3eb2f6b10538efff2d637c923efa4bfca048"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 


### PR DESCRIPTION
Make use of [dimforge/rapier@`1b449fc` (#446)](https://github.com/dimforge/rapier/pull/446/commits/1b449fc31df6b9ecb8d339a5ff5fb2c1763a7978) and [dimforge/rapier@`dd195a4` (#446)](https://github.com/dimforge/rapier/pull/446/commits/dd195a47203ec4d9540f1a656ac53859372d353f)
Fix #98 well enough for the moment 😃 
Only jank remaining is when moving against edges, but at least walking on the ground and walking along a wall are nice!