### PR TITLE
Fix missing normalizations

### DIFF
--- a/src/player_control/camera/third_person.rs
+++ b/src/player_control/camera/third_person.rs
@@ -150,9 +150,11 @@ impl ThirdPersonCamera {
         if target_to_secondary_target.is_approx_zero() {
             return;
         }
+        let target_to_secondary_target = target_to_secondary_target.normalize();
         let eye_to_target = (self.target - self.transform.translation)
             .split(self.up)
-            .horizontal;
+            .horizontal
+            .normalize();
         let rotation = Quat::from_rotation_arc(eye_to_target, target_to_secondary_target);
         let pivot = self.target;
         self.transform.rotate_around(pivot, rotation);


### PR DESCRIPTION
This should make the unit tests stop failing again.
Partial revert of https://github.com/janhohenheim/foxtrot/commit/9f3492a85d820a5b745aaca132ec1defd9cfd2d7