### PR TITLE
Use correct homebrew path on ARM macs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,7 @@ rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Zshare-generics=y"]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Zshare-generics=y"]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"


### PR DESCRIPTION
Homebrew installs packages to a different directory on Apple Silicon Macs, so this template was not working out of the box due to the incorrect path for `zld`. I've made the appropriate fix in `.cargo/config.toml`