### PR TITLE
Added bevy_editor_pls editor component to camera rig

### DIFF
--- a/src/level_instantiation/spawning/objects/camera.rs
+++ b/src/level_instantiation/spawning/objects/camera.rs
@@ -3,6 +3,7 @@ use crate::player_control::actions::create_camera_action_input_manager_bundle;
 use crate::player_control::camera::IngameCamera;
 use bevy::prelude::*;
 use bevy_dolly::prelude::*;
+use bevy_editor_pls::default_windows::cameras::EditorCamera;
 
 pub(crate) fn spawn(In(transform): In<Transform>, mut commands: Commands) {
     commands.spawn((
@@ -21,5 +22,6 @@ pub(crate) fn spawn(In(transform): In<Transform>, mut commands: Commands) {
         create_camera_action_input_manager_bundle(),
         Name::new("Main Camera"),
         GameObject::Camera,
+        EditorCamera,
     ));
 }


### PR DESCRIPTION
Fixes #246 
Though it might still need some work on the input side (Pressing esc) as to when to control the player vs the camera.

Works for both 3D (Free) orbit and (Pan/Orbit), see images below:
![image](https://user-images.githubusercontent.com/25123512/228585795-f53ef22d-8f5b-4e40-87ff-3c7601c95393.png)
![image](https://user-images.githubusercontent.com/25123512/228585949-70a31fc9-682a-42f4-8e99-4a78fa7638c4.png)
