### PR TITLE
Update Rust action in CI and simplify caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
 
+env:
+  CARGO_TERM_COLOR: always
+  NIGHTLY_TOOLCHAIN: nightly-2023-03-01
+
 jobs:
   test-native:
     strategy:
@@ -21,10 +25,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
@@ -33,7 +36,7 @@ jobs:
         if: runner.os == 'macos'
       - name: Install llvm tools
         run: cargo install -f cargo-binutils && rustup component add llvm-tools-preview
-        if : runner.os == 'windows'
+        if: runner.os == 'windows'
       - name: Build & run tests for native
         run: cargo test
   test-native-docs:
@@ -49,10 +52,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run doc tests
@@ -70,16 +72,15 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Install trunk
         uses: jetli/trunk-action@v0.1.0
         with:
-          version: 'v0.16.0'
+          version: "v0.16.0"
       - name: Add wasm target
         run: |
           rustup target add wasm32-unknown-unknown
@@ -98,11 +99,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           components: rustfmt, clippy
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
@@ -43,18 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run doc tests
@@ -63,18 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Install trunk
@@ -90,19 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ubuntu-latest-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           components: rustfmt, clippy
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check format

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -3,6 +3,10 @@ name: deploy-github-page
 on:
   workflow_dispatch:
 
+env:
+  CARGO_TERM_COLOR: always
+  NIGHTLY_TOOLCHAIN: nightly-2023-03-01
+
 jobs:
   build-web:
     runs-on: ubuntu-latest
@@ -11,16 +15,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Install trunk
         uses: jetli/trunk-action@v0.1.0
         with:
-          version: 'v0.16.0'
+          version: "v0.16.0"
       - name: Add wasm target
         run: |
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ env:
   GAME_EXECUTABLE_NAME: foxtrot
   GAME_OSX_APP_NAME: Foxtrot
 
+  CARGO_TERM_COLOR: always
+  NIGHTLY_TOOLCHAIN: nightly-2023-03-01
+
 permissions:
   contents: write
 
@@ -19,8 +22,8 @@ jobs:
     runs-on: macos-latest
 
     env:
-        # macOS 11.0 Big Sur is the first version of macOS to support universal binaries
-        MACOSX_DEPLOYMENT_TARGET: 11.0
+      # macOS 11.0 Big Sur is the first version of macOS to support universal binaries
+      MACOSX_DEPLOYMENT_TARGET: 11.0
     steps:
       - name: Get tag
         id: tag
@@ -36,9 +39,9 @@ jobs:
         run: |
           rm build.rs
       - name: Install rust toolchain for Apple Silicon
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           target: aarch64-apple-darwin
           override: true
       - name: Install zld
@@ -48,9 +51,9 @@ jobs:
         run: |
           SDKROOT=$(xcrun -sdk macosx --show-sdk-path) RUSTFLAGS="-C link-arg=-fuse-ld=/usr/local/bin/zld -Z share-generics=y" cargo build --release --no-default-features --features native --target=aarch64-apple-darwin
       - name: Install rust toolchain for Apple x86
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           target: x86_64-apple-darwin
           override: true
       - name: Build release for x86 Apple
@@ -93,10 +96,9 @@ jobs:
         run: |
           git lfs pull
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Build release
@@ -134,10 +136,9 @@ jobs:
         run: |
           git lfs pull
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install dotnet
         uses: actions/setup-dotnet@v3
         with:
@@ -167,11 +168,11 @@ jobs:
       - name: Upload installer
         uses: svenstaro/upload-release-action@v2
         with:
-         repo_token: ${{ secrets.GITHUB_TOKEN }}
-         file: installer/en-US/installer.msi
-         asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_windows.msi
-         tag: ${{ github.ref }}
-         overwrite: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: installer/en-US/installer.msi
+          asset_name: ${{ env.GAME_EXECUTABLE_NAME }}_${{ steps.tag.outputs.tag }}_windows.msi
+          tag: ${{ github.ref }}
+          overwrite: true
   build-web:
     runs-on: ubuntu-latest
 
@@ -184,16 +185,15 @@ jobs:
         run: |
           git lfs pull
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-01
-          override: true
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Install trunk
         uses: jetli/trunk-action@v0.1.0
         with:
-          version: 'v0.16.0'
+          version: "v0.16.0"
       - name: Add wasm target
         run: |
           rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
Closes #124.

In this PR, the mostly unmaintained `actions-rs/toolchain` action is replaced by `dtolnay/rust-toolchain` which is also used in Bevy's CI now.

Additionally, the [`Leafwing-Studios/cargo-cache`](https://github.com/Leafwing-Studios/cargo-cache) action is used to greatly simplify the build file caching in the workflows.