### PR TITLE
Enable full-screen

### DIFF
--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -25,3 +25,31 @@ html {
     white 20px
   );
 }
+
+.loader {
+  --loader-size: 32px;
+  --loader-position-y: 155px;
+  position: fixed;
+  left: calc(50% - var(--loader-size) / 2);
+  top: calc(50% - var(--game-ui-height) / 2 + var(--loader-position-y));
+  width: var(--loader-size);
+  height: var(--loader-size);
+  border: 3px solid #005c80;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  box-sizing: border-box;
+  animation: rotation 2s linear infinite;
+}
+
+.loader:not([hidden]) {
+  display: inline-block;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -31,7 +31,7 @@ html {
   --loader-position-y: 155px;
   position: fixed;
   left: calc(50% - var(--loader-size) / 2);
-  top: calc(50% - var(--game-ui-height) / 2 + var(--loader-position-y));
+  top: var(--loader-position-y);
   width: var(--loader-size);
   height: var(--loader-size);
   border: 3px solid #005c80;

--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -1,56 +1,55 @@
-:root {
-    --game-ui-height: 600px;
-}
-
-body, html {
-    height: 100%;
-}
-
-body {
-    background: repeating-linear-gradient(
-            135deg,
-            black 0,
-            black 2px,
-            white 2px,
-            white 20px
-    );
-    margin: 0;
+body,
+html {
+  height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .game-container {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 #bevy {
-    background-color: white;
-    width: 800px;
-    height: var(--game-ui-height);
+  width: 100%;
+  height: 100%;
+
+  background: repeating-linear-gradient(
+    135deg,
+    black 0,
+    black 2px,
+    white 2px,
+    white 20px
+  );
 }
 
 .loader {
-    --loader-size: 32px;
-    --loader-position-y: 155px;
-    position: fixed;
-    left: calc(50% - var(--loader-size) / 2);
-    top: calc(50% - var(--game-ui-height) / 2 + var(--loader-position-y));
-    width: var(--loader-size);
-    height: var(--loader-size);
-    border: 3px solid #005c80;
-    border-bottom-color: transparent;
-    border-radius: 50%;
-    box-sizing: border-box;
-    animation: rotation 2s linear infinite;
+  --loader-size: 32px;
+  --loader-position-y: 155px;
+  position: fixed;
+  left: calc(50% - var(--loader-size) / 2);
+  top: calc(50% - var(--game-ui-height) / 2 + var(--loader-position-y));
+  width: var(--loader-size);
+  height: var(--loader-size);
+  border: 3px solid #005c80;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  box-sizing: border-box;
+  animation: rotation 2s linear infinite;
 }
 
 .loader:not([hidden]) {
-    display: inline-block;
+  display: inline-block;
 }
 
 @keyframes rotation {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/build/web/styles.css
+++ b/build/web/styles.css
@@ -25,31 +25,3 @@ html {
     white 20px
   );
 }
-
-.loader {
-  --loader-size: 32px;
-  --loader-position-y: 155px;
-  position: fixed;
-  left: calc(50% - var(--loader-size) / 2);
-  top: calc(50% - var(--game-ui-height) / 2 + var(--loader-position-y));
-  width: var(--loader-size);
-  height: var(--loader-size);
-  border: 3px solid #005c80;
-  border-bottom-color: transparent;
-  border-radius: 50%;
-  box-sizing: border-box;
-  animation: rotation 2s linear infinite;
-}
-
-.loader:not([hidden]) {
-  display: inline-block;
-}
-
-@keyframes rotation {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}

--- a/index.html
+++ b/index.html
@@ -1,18 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
+<head>
+    <meta charset="utf-8"/>
     <title>Foxtrot</title>
-    <link data-trunk rel="copy-dir" href="assets" />
-    <link data-trunk rel="copy-dir" href="credits" />
-    <link data-trunk rel="copy-file" href="build/windows/icon.ico" />
-    <link rel="icon" href="icon.ico" />
-    <link data-trunk rel="inline" href="build/web/styles.css" />
-  </head>
-  <body>
-    <link data-trunk rel="inline" href="build/web/sound.js" />
-    <div class="game-container">
-      <canvas id="bevy"> Javascript and support for canvas is required </canvas>
-    </div>
-  </body>
+    <link data-trunk rel="copy-dir" href="assets"/>
+    <link data-trunk rel="copy-dir" href="credits"/>
+    <link data-trunk rel="copy-file" href="build/windows/icon.ico"/>
+    <link rel="icon" href="icon.ico">
+    <link data-trunk rel="inline" href="build/web/styles.css"/>
+</head>
+<body>
+<link data-trunk rel="inline" href="build/web/sound.js"/>
+<div class="loader" hidden></div>
+<div class="game-container">
+    <canvas id="bevy">
+        Javascript and support for canvas is required
+    </canvas>
+</div>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,21 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8"/>
+  <head>
+    <meta charset="utf-8" />
     <title>Foxtrot</title>
-    <link data-trunk rel="copy-dir" href="assets"/>
-    <link data-trunk rel="copy-dir" href="credits"/>
-    <link data-trunk rel="copy-file" href="build/windows/icon.ico"/>
-    <link rel="icon" href="icon.ico">
-    <link data-trunk rel="inline" href="build/web/styles.css"/>
-</head>
-<body>
-<link data-trunk rel="inline" href="build/web/sound.js"/>
-<div class="loader" hidden></div>
-<div class="game-container">
-    <canvas id="bevy">
-        Javascript and support for canvas is required
-    </canvas>
-</div>
-</body>
+    <link data-trunk rel="copy-dir" href="assets" />
+    <link data-trunk rel="copy-dir" href="credits" />
+    <link data-trunk rel="copy-file" href="build/windows/icon.ico" />
+    <link rel="icon" href="icon.ico" />
+    <link data-trunk rel="inline" href="build/web/styles.css" />
+  </head>
+  <body>
+    <link data-trunk rel="inline" href="build/web/sound.js" />
+    <div class="game-container">
+      <canvas id="bevy"> Javascript and support for canvas is required </canvas>
+    </div>
+  </body>
 </html>

--- a/src/bevy_config.rs
+++ b/src/bevy_config.rs
@@ -19,7 +19,7 @@ pub fn bevy_config_plugin(app: &mut App) {
             present_mode: PresentMode::AutoVsync,
             // This breaks WASM for some reason
             #[cfg(not(feature = "wasm"))]
-            mode: WindowMode::Fullscreen,
+            mode: WindowMode::BorderlessFullscreen,
             fit_canvas_to_parent: true,
             ..default()
         }),

--- a/src/bevy_config.rs
+++ b/src/bevy_config.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use bevy::prelude::*;
 use bevy::window::PresentMode;
 use bevy::window::PrimaryWindow;
+#[cfg(not(feature = "wasm"))]
+use bevy::window::WindowMode;
 use bevy::winit::WinitWindows;
 use bevy_mod_sysfail::macros::*;
 use std::io::Cursor;
@@ -15,6 +17,10 @@ pub fn bevy_config_plugin(app: &mut App) {
             title: "Foxtrot".to_string(),
             canvas: Some("#bevy".to_owned()),
             present_mode: PresentMode::AutoVsync,
+            // This breaks WASM for some reason
+            #[cfg(not(feature = "wasm"))]
+            mode: WindowMode::Fullscreen,
+            fit_canvas_to_parent: true,
             ..default()
         }),
         ..default()

--- a/src/ingame_menu.rs
+++ b/src/ingame_menu.rs
@@ -1,5 +1,6 @@
 use crate::player_control::actions::{ActionsFrozen, UiAction};
 use crate::GameState;
+use bevy::app::AppExit;
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
 use leafwing_input_manager::prelude::ActionState;
@@ -12,6 +13,7 @@ pub fn ingame_menu_plugin(app: &mut App) {
 fn handle_pause(
     mut time: ResMut<Time>,
     actions: Query<&ActionState<UiAction>>,
+    mut app_exit_events: EventWriter<AppExit>,
     mut actions_frozen: ResMut<ActionsFrozen>,
     mut egui_contexts: EguiContexts,
     mut paused: Local<bool>,
@@ -37,6 +39,12 @@ fn handle_pause(
                             ui.heading("Game Paused");
                             ui.separator();
                             ui.label("Press ESC to resume");
+
+                            ui.add_space(100.0);
+
+                            if ui.button("Quit Game").clicked() {
+                                app_exit_events.send(AppExit);
+                            }
                         });
                     });
             }

--- a/src/ingame_menu.rs
+++ b/src/ingame_menu.rs
@@ -44,6 +44,8 @@ fn handle_pause(
 
                             if ui.button("Quit Game").clicked() {
                                 app_exit_events.send(AppExit);
+                                #[cfg(feature = "wasm")]
+                                wasm::close_tab()
                             }
                         });
                     });
@@ -53,5 +55,18 @@ fn handle_pause(
             time.pause();
             actions_frozen.freeze();
         }
+    }
+}
+
+#[cfg(feature = "wasm")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(inline_js = "
+        export function close_tab() {
+            window.close();
+        }")]
+    extern "C" {
+        pub(crate) fn close_tab();
     }
 }

--- a/src/level_instantiation/map.rs
+++ b/src/level_instantiation/map.rs
@@ -49,6 +49,10 @@ fn show_loading_screen(mut egui_contexts: EguiContexts) {
             ui.heading("Loading");
             ui.label("Spawning level...");
             ui.add_space(10.0);
+            #[cfg(feature = "wasm")]
+            ui.add_space(40.0); // Spinner from CSS (build/web/styles.css) goes here.
+            #[cfg(feature = "wasm")]
+            ui.label("This may take a while. Don't worry, your browser did not crash!");
         });
     });
 }

--- a/src/level_instantiation/map.rs
+++ b/src/level_instantiation/map.rs
@@ -17,8 +17,6 @@ pub fn map_plugin(app: &mut App) {
             .run_if(not(any_with_component::<Player>()))
             .in_set(OnUpdate(GameState::Playing)),
     );
-    #[cfg(feature = "wasm")]
-    app.add_system(show_wasm_loader.in_set(OnUpdate(GameState::Playing)));
 }
 
 fn setup(
@@ -48,47 +46,6 @@ fn show_loading_screen(mut egui_contexts: EguiContexts) {
             ui.heading("Loading");
             ui.label("Spawning level...");
             ui.add_space(10.0);
-            #[cfg(feature = "wasm")]
-            ui.add_space(40.0); // Spinner from CSS (build/web/styles.css) goes here.
-            #[cfg(feature = "wasm")]
-            ui.label("This may take a while. Don't worry, your browser did not crash!");
         });
     });
-}
-
-#[cfg(feature = "wasm")]
-fn show_wasm_loader(player_query: Query<&Player>, mut egui_contexts: EguiContexts) {
-    let id = egui::Id::new("loading-screen-shown");
-    egui_contexts.ctx_mut().memory_mut(|memory| {
-        let memory = &mut memory.data;
-        match (memory.get_temp::<()>(id), player_query.iter().next()) {
-            (None, None) => {
-                loader::show_loader();
-                memory.insert_temp(id, ());
-            }
-            (Some(_), Some(_)) => {
-                loader::hide_loader();
-                memory.remove::<()>(id);
-            }
-            _ => {}
-        }
-    });
-}
-
-#[cfg(feature = "wasm")]
-mod loader {
-    use wasm_bindgen::prelude::*;
-
-    #[wasm_bindgen(inline_js = "
-        export function show_loader() {
-            document.querySelector('.loader').hidden = false;
-        }
-        export function hide_loader() {
-            document.querySelector('.loader').hidden = true;
-        }")]
-    extern "C" {
-        pub fn show_loader();
-
-        pub fn hide_loader();
-    }
 }

--- a/src/level_instantiation/map.rs
+++ b/src/level_instantiation/map.rs
@@ -17,6 +17,9 @@ pub(crate) fn map_plugin(app: &mut App) {
             .run_if(not(any_with_component::<Player>()))
             .in_set(OnUpdate(GameState::Playing)),
     );
+
+    #[cfg(feature = "wasm")]
+    app.add_system(show_wasm_loader.in_set(OnUpdate(GameState::Playing)));
 }
 
 fn setup(


### PR DESCRIPTION
Closes #252.

This PR enables full-screen for both native and web builds.

Unfortunately this makes the web page a bit less pretty until the game loads in.
I propose to fix that with a proper loading screen (in HTML/JS), I have a prototype for that here: <https://github.com/ramirezmike/game_off_2022/pull/1>.
That's a topic for a future PR though.

I also added a (very primitive) exit button to the pause menu so that you don't get stuck in the game on native.