### PR TITLE
Use `pub(crate)` instead of `pub`

### DIFF
--- a/src/bevy_config.rs
+++ b/src/bevy_config.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 use winit::window::Icon;
 
 /// Overrides the default Bevy plugins and configures things like the screen settings.
-pub fn bevy_config_plugin(app: &mut App) {
+pub(crate) fn bevy_config_plugin(app: &mut App) {
     let default_plugins = DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
             resolution: (800., 600.).into(),

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -6,11 +6,11 @@ use bevy_prototype_debug_lines::DebugLinesPlugin;
 use bevy_rapier3d::prelude::*;
 use seldom_fn_plugin::FnPluginExt;
 
-pub mod dev_editor;
+pub(crate) mod dev_editor;
 
 /// Plugin with debugging utility intended for use during development only.
 /// Don't include this in a release build.
-pub fn dev_plugin(app: &mut App) {
+pub(crate) fn dev_plugin(app: &mut App) {
     {
         app.add_plugin(EditorPlugin)
             .insert_resource(default_editor_controls())

--- a/src/dev/dev_editor.rs
+++ b/src/dev/dev_editor.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use spew::prelude::*;
 use strum::IntoEnumIterator;
 
-pub fn dev_editor_plugin(app: &mut App) {
+pub(crate) fn dev_editor_plugin(app: &mut App) {
     app.init_resource::<DevEditorState>()
         .add_editor_window::<DevEditorWindow>()
         .add_systems(
@@ -31,7 +31,7 @@ pub fn dev_editor_plugin(app: &mut App) {
         );
 }
 
-pub struct DevEditorWindow;
+pub(crate) struct DevEditorWindow;
 
 impl EditorWindow for DevEditorWindow {
     type State = DevEditorState;
@@ -122,13 +122,13 @@ impl EditorWindow for DevEditorWindow {
 
 #[derive(Debug, Clone, Eq, PartialEq, Resource, Reflect, Serialize, Deserialize)]
 #[reflect(Resource, Serialize, Deserialize)]
-pub struct DevEditorState {
-    pub open: bool,
-    pub level_name: String,
-    pub save_name: String,
-    pub spawn_item: GameObject,
-    pub collider_render_enabled: bool,
-    pub navmesh_render_enabled: bool,
+pub(crate) struct DevEditorState {
+    pub(crate) open: bool,
+    pub(crate) level_name: String,
+    pub(crate) save_name: String,
+    pub(crate) spawn_item: GameObject,
+    pub(crate) collider_render_enabled: bool,
+    pub(crate) navmesh_render_enabled: bool,
 }
 
 impl Default for DevEditorState {

--- a/src/file_system_interaction.rs
+++ b/src/file_system_interaction.rs
@@ -1,8 +1,8 @@
-pub mod asset_loading;
-pub mod audio;
-pub mod config;
-pub mod game_state_serialization;
-pub mod level_serialization;
+pub(crate) mod asset_loading;
+pub(crate) mod audio;
+pub(crate) mod config;
+pub(crate) mod game_state_serialization;
+pub(crate) mod level_serialization;
 
 use bevy::prelude::*;
 
@@ -18,7 +18,7 @@ use seldom_fn_plugin::FnPluginExt;
 /// - [`game_state_serialization_plugin`] handles saving and loading of game states.
 /// - [`level_serialization_plugin`] handles saving and loading of levels.
 /// - [`internal_audio_plugin`]: Handles audio initialization
-pub fn file_system_interaction_plugin(app: &mut App) {
+pub(crate) fn file_system_interaction_plugin(app: &mut App) {
     app.fn_plugin(loading_plugin)
         .fn_plugin(game_state_serialization_plugin)
         .fn_plugin(level_serialization_plugin)

--- a/src/file_system_interaction/asset_loading.rs
+++ b/src/file_system_interaction/asset_loading.rs
@@ -14,7 +14,7 @@ use bevy_kira_audio::AudioSource;
 use bevy_mod_sysfail::macros::*;
 use iyes_progress::{ProgressCounter, ProgressPlugin};
 
-pub fn loading_plugin(app: &mut App) {
+pub(crate) fn loading_plugin(app: &mut App) {
     app.add_plugin(RonAssetPlugin::<SerializedLevel>::new(&["lvl.ron"]))
         .add_plugin(RonAssetPlugin::<Dialog>::new(&["dlg.ron"]))
         .add_plugin(TomlAssetPlugin::<GameConfig>::new(&["game.toml"]))
@@ -35,61 +35,61 @@ pub fn loading_plugin(app: &mut App) {
 // when done loading, they will be inserted as resources (see <https://github.com/NiklasEi/bevy_asset_loader>)
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct AudioAssets {
+pub(crate) struct AudioAssets {
     #[asset(path = "audio/walking.ogg")]
-    pub walking: Handle<AudioSource>,
+    pub(crate) walking: Handle<AudioSource>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct SceneAssets {
+pub(crate) struct SceneAssets {
     #[asset(path = "scenes/Fox.glb#Scene0")]
-    pub character: Handle<Scene>,
+    pub(crate) character: Handle<Scene>,
     #[asset(path = "scenes/old_town.glb#Scene0")]
-    pub level: Handle<Scene>,
+    pub(crate) level: Handle<Scene>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct AnimationAssets {
+pub(crate) struct AnimationAssets {
     #[asset(path = "scenes/Fox.glb#Animation0")]
-    pub character_idle: Handle<AnimationClip>,
+    pub(crate) character_idle: Handle<AnimationClip>,
     #[asset(path = "scenes/Fox.glb#Animation1")]
-    pub character_walking: Handle<AnimationClip>,
+    pub(crate) character_walking: Handle<AnimationClip>,
     #[asset(path = "scenes/Fox.glb#Animation2")]
-    pub character_running: Handle<AnimationClip>,
+    pub(crate) character_running: Handle<AnimationClip>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct LevelAssets {
+pub(crate) struct LevelAssets {
     #[cfg_attr(feature = "native", asset(path = "levels", collection(typed, mapped)))]
     #[cfg_attr(
         feature = "wasm",
         asset(paths("levels/old_town.lvl.ron"), collection(typed, mapped))
     )]
-    pub levels: HashMap<String, Handle<SerializedLevel>>,
+    pub(crate) levels: HashMap<String, Handle<SerializedLevel>>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct DialogAssets {
+pub(crate) struct DialogAssets {
     #[cfg_attr(feature = "native", asset(path = "dialogs", collection(typed, mapped)))]
     #[cfg_attr(
         feature = "wasm",
         asset(paths("dialogs/follower.dlg.ron"), collection(typed, mapped))
     )]
-    pub dialogs: HashMap<String, Handle<Dialog>>,
+    pub(crate) dialogs: HashMap<String, Handle<Dialog>>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct TextureAssets {
+pub(crate) struct TextureAssets {
     #[asset(path = "textures/stone_alley_2.jpg")]
-    pub glowy_interior: Handle<Image>,
+    pub(crate) glowy_interior: Handle<Image>,
     #[asset(path = "textures/sky.jpg")]
-    pub sky: Handle<Image>,
+    pub(crate) sky: Handle<Image>,
 }
 
 #[derive(AssetCollection, Resource, Clone)]
-pub struct ConfigAssets {
+pub(crate) struct ConfigAssets {
     #[asset(path = "config/config.game.toml")]
-    pub game: Handle<GameConfig>,
+    pub(crate) game: Handle<GameConfig>,
 }
 
 fn show_progress(

--- a/src/file_system_interaction/asset_loading.rs
+++ b/src/file_system_interaction/asset_loading.rs
@@ -88,6 +88,7 @@ pub(crate) struct TextureAssets {
 
 #[derive(AssetCollection, Resource, Clone)]
 pub(crate) struct ConfigAssets {
+    #[allow(dead_code)]
     #[asset(path = "config/config.game.toml")]
     pub(crate) game: Handle<GameConfig>,
 }

--- a/src/file_system_interaction/audio.rs
+++ b/src/file_system_interaction/audio.rs
@@ -4,14 +4,14 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::{Audio, *};
 
 /// Handles initialization of all sounds.
-pub fn internal_audio_plugin(app: &mut App) {
+pub(crate) fn internal_audio_plugin(app: &mut App) {
     app.add_plugin(AudioPlugin)
         .add_system(init_audio.in_schedule(OnExit(GameState::Loading)));
 }
 
 #[derive(Debug, Clone, Resource)]
-pub struct AudioHandles {
-    pub walking: Handle<AudioInstance>,
+pub(crate) struct AudioHandles {
+    pub(crate) walking: Handle<AudioInstance>,
 }
 
 fn init_audio(mut commands: Commands, audio_assets: Res<AudioAssets>, audio: Res<Audio>) {

--- a/src/file_system_interaction/config.rs
+++ b/src/file_system_interaction/config.rs
@@ -16,81 +16,81 @@ use serde::{Deserialize, Serialize};
 )]
 #[reflect(Serialize, Deserialize, Resource)]
 #[uuid = "93a7c64b-4d6e-4420-b8c1-dfca481d9387"]
-pub struct GameConfig {
-    pub camera: Camera,
-    pub characters: Characters,
-    pub player: Player,
-    pub dialog: Dialog,
+pub(crate) struct GameConfig {
+    pub(crate) camera: Camera,
+    pub(crate) characters: Characters,
+    pub(crate) player: Player,
+    pub(crate) dialog: Dialog,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct Camera {
-    pub fixed_angle: FixedAngle,
-    pub first_person: FirstPerson,
-    pub third_person: ThirdPerson,
-    pub mouse_sensitivity_x: f32,
-    pub mouse_sensitivity_y: f32,
+pub(crate) struct Camera {
+    pub(crate) fixed_angle: FixedAngle,
+    pub(crate) first_person: FirstPerson,
+    pub(crate) third_person: ThirdPerson,
+    pub(crate) mouse_sensitivity_x: f32,
+    pub(crate) mouse_sensitivity_y: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct FixedAngle {
-    pub min_distance: f32,
-    pub max_distance: f32,
-    pub zoom_speed: f32,
-    pub rotation_smoothing: f32,
-    pub translation_smoothing: f32,
-    pub zoom_in_smoothing: f32,
-    pub zoom_out_smoothing: f32,
-    pub pitch: f32,
+pub(crate) struct FixedAngle {
+    pub(crate) min_distance: f32,
+    pub(crate) max_distance: f32,
+    pub(crate) zoom_speed: f32,
+    pub(crate) rotation_smoothing: f32,
+    pub(crate) translation_smoothing: f32,
+    pub(crate) zoom_in_smoothing: f32,
+    pub(crate) zoom_out_smoothing: f32,
+    pub(crate) pitch: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct FirstPerson {
-    pub translation_smoothing: f32,
-    pub rotation_smoothing: f32,
-    pub max_pitch: f32,
-    pub min_pitch: f32,
-    pub tracking_smoothing: f32,
+pub(crate) struct FirstPerson {
+    pub(crate) translation_smoothing: f32,
+    pub(crate) rotation_smoothing: f32,
+    pub(crate) max_pitch: f32,
+    pub(crate) min_pitch: f32,
+    pub(crate) tracking_smoothing: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct ThirdPerson {
-    pub translation_smoothing: f32,
-    pub rotation_smoothing: f32,
-    pub max_pitch: f32,
-    pub min_pitch: f32,
-    pub min_distance: f32,
-    pub max_distance: f32,
-    pub zoom_speed: f32,
-    pub min_distance_to_objects: f32,
-    pub tracking_smoothing: f32,
-    pub zoom_in_smoothing: f32,
-    pub zoom_out_smoothing: f32,
+pub(crate) struct ThirdPerson {
+    pub(crate) translation_smoothing: f32,
+    pub(crate) rotation_smoothing: f32,
+    pub(crate) max_pitch: f32,
+    pub(crate) min_pitch: f32,
+    pub(crate) min_distance: f32,
+    pub(crate) max_distance: f32,
+    pub(crate) zoom_speed: f32,
+    pub(crate) min_distance_to_objects: f32,
+    pub(crate) tracking_smoothing: f32,
+    pub(crate) zoom_in_smoothing: f32,
+    pub(crate) zoom_out_smoothing: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct Characters {
-    pub model_sync_smoothing: f32,
-    pub rotation_smoothing: f32,
+pub(crate) struct Characters {
+    pub(crate) model_sync_smoothing: f32,
+    pub(crate) rotation_smoothing: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct Player {
-    pub rotate_to_speaker_smoothness: f32,
-    pub sprint_effect_speed_threshold: f32,
-    pub fov_saturation_speed: f32,
-    pub min_fov: f32,
-    pub max_fov: f32,
+pub(crate) struct Player {
+    pub(crate) rotate_to_speaker_smoothness: f32,
+    pub(crate) sprint_effect_speed_threshold: f32,
+    pub(crate) fov_saturation_speed: f32,
+    pub(crate) min_fov: f32,
+    pub(crate) max_fov: f32,
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct Dialog {
-    pub base_letters_per_second: f32,
+pub(crate) struct Dialog {
+    pub(crate) base_letters_per_second: f32,
 }

--- a/src/file_system_interaction/game_state_serialization.rs
+++ b/src/file_system_interaction/game_state_serialization.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub fn game_state_serialization_plugin(app: &mut App) {
+pub(crate) fn game_state_serialization_plugin(app: &mut App) {
     app.add_event::<GameSaveRequest>()
         .add_event::<GameLoadRequest>()
         .add_systems(
@@ -29,13 +29,13 @@ pub fn game_state_serialization_plugin(app: &mut App) {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Resource, Serialize, Deserialize, Default)]
-pub struct GameSaveRequest {
-    pub filename: Option<String>,
+pub(crate) struct GameSaveRequest {
+    pub(crate) filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Resource, Serialize, Deserialize, Default)]
-pub struct GameLoadRequest {
-    pub filename: Option<String>,
+pub(crate) struct GameLoadRequest {
+    pub(crate) filename: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Resource, Serialize, Deserialize, Default)]

--- a/src/file_system_interaction/level_serialization.rs
+++ b/src/file_system_interaction/level_serialization.rs
@@ -12,7 +12,7 @@ use spew::prelude::*;
 use std::path::Path;
 use std::{fs, iter};
 
-pub fn level_serialization_plugin(app: &mut App) {
+pub(crate) fn level_serialization_plugin(app: &mut App) {
     app.add_event::<WorldSaveRequest>()
         .add_event::<WorldLoadRequest>()
         .add_systems(
@@ -26,20 +26,20 @@ pub fn level_serialization_plugin(app: &mut App) {
 
 #[derive(Debug, Clone, Eq, PartialEq, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct WorldSaveRequest {
-    pub filename: String,
+pub(crate) struct WorldSaveRequest {
+    pub(crate) filename: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub struct WorldLoadRequest {
-    pub filename: String,
+pub(crate) struct WorldLoadRequest {
+    pub(crate) filename: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Resource, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Resource, Serialize, Deserialize)]
-pub struct CurrentLevel {
-    pub scene: String,
+pub(crate) struct CurrentLevel {
+    pub(crate) scene: String,
 }
 
 #[sysfail(log(level = "error"))]
@@ -90,7 +90,7 @@ fn save_world(
 
 #[derive(Debug, Component, Clone, PartialEq, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Protected;
+pub(crate) struct Protected;
 
 #[sysfail(log(level = "error"))]
 fn load_world(
@@ -167,7 +167,7 @@ fn serialize_world(spawn_query: &Query<(&GameObject, Option<&Transform>)>) -> Re
 #[derive(Debug, Clone, PartialEq, Reflect, Serialize, Deserialize, TypeUuid, Deref, DerefMut)]
 #[uuid = "eb7cc7bc-5a97-41ed-b0c3-0d4e2137b73b"]
 #[reflect(Serialize, Deserialize)]
-pub struct SerializedLevel(pub Vec<(GameObject, Transform)>);
+pub(crate) struct SerializedLevel(pub(crate) Vec<(GameObject, Transform)>);
 
 impl From<Vec<SpawnEvent<GameObject, Transform>>> for SerializedLevel {
     fn from(events: Vec<SpawnEvent<GameObject, Transform>>) -> Self {

--- a/src/ingame_menu.rs
+++ b/src/ingame_menu.rs
@@ -5,7 +5,7 @@ use bevy_egui::{egui, EguiContexts};
 use leafwing_input_manager::prelude::ActionState;
 
 /// Handles the pause menu accessed while playing the game via ESC.
-pub fn ingame_menu_plugin(app: &mut App) {
+pub(crate) fn ingame_menu_plugin(app: &mut App) {
     app.add_system(handle_pause.in_set(OnUpdate(GameState::Playing)));
 }
 

--- a/src/level_instantiation.rs
+++ b/src/level_instantiation.rs
@@ -1,6 +1,6 @@
-pub mod grass;
-pub mod map;
-pub mod spawning;
+pub(crate) mod grass;
+pub(crate) mod map;
+pub(crate) mod spawning;
 
 use crate::level_instantiation::grass::grass_plugin;
 use crate::level_instantiation::map::map_plugin;
@@ -12,7 +12,7 @@ use seldom_fn_plugin::FnPluginExt;
 /// - [`map_plugin`] handles loading of level files and orchestrates the spawning of the objects therein.
 /// - [`spawning_plugin`] handles the spawning of objects in general.
 /// - [`grass_plugin`] handles the spawning of grass on top of marked meshes.
-pub fn level_instantiation_plugin(app: &mut App) {
+pub(crate) fn level_instantiation_plugin(app: &mut App) {
     app.fn_plugin(map_plugin)
         .fn_plugin(spawning_plugin)
         .fn_plugin(grass_plugin);

--- a/src/level_instantiation/grass.rs
+++ b/src/level_instantiation/grass.rs
@@ -7,7 +7,7 @@ use bevy_mod_sysfail::macros::*;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use warbler_grass::prelude::*;
 
-pub fn grass_plugin(app: &mut App) {
+pub(crate) fn grass_plugin(app: &mut App) {
     app.add_plugin(WarblersPlugin).add_system(
         add_grass
             .after(TransformSystem::TransformPropagate)
@@ -16,7 +16,7 @@ pub fn grass_plugin(app: &mut App) {
 }
 
 #[sysfail(log(level = "error"))]
-pub fn add_grass(
+pub(crate) fn add_grass(
     mut commands: Commands,
     added_name: Query<(Entity, &Name), Added<Name>>,
     meshes: Res<Assets<Mesh>>,

--- a/src/level_instantiation/map.rs
+++ b/src/level_instantiation/map.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
 use spew::prelude::*;
 
-pub fn map_plugin(app: &mut App) {
+pub(crate) fn map_plugin(app: &mut App) {
     app.add_system(
         setup
             .run_if(not(resource_exists::<CurrentLevel>()))
@@ -87,8 +87,8 @@ mod loader {
             document.querySelector('.loader').hidden = true;
         }")]
     extern "C" {
-        pub fn show_loader();
+        pub(crate) fn show_loader();
 
-        pub fn hide_loader();
+        pub(crate) fn hide_loader();
     }
 }

--- a/src/level_instantiation/spawning.rs
+++ b/src/level_instantiation/spawning.rs
@@ -4,7 +4,7 @@ use crate::level_instantiation::spawning::post_spawn_modification::{
     despawn_removed, set_color, set_hidden, set_shadows,
 };
 use crate::GameState;
-pub use animation_link::AnimationEntityLink;
+pub(crate) use animation_link::AnimationEntityLink;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use spew::prelude::*;
@@ -12,10 +12,10 @@ use strum_macros::EnumIter;
 
 mod animation_link;
 mod despawn;
-pub mod objects;
+pub(crate) mod objects;
 mod post_spawn_modification;
 
-pub fn spawning_plugin(app: &mut App) {
+pub(crate) fn spawning_plugin(app: &mut App) {
     app.add_plugin(SpewPlugin::<GameObject, Transform>::default())
         .register_type::<Despawn>()
         .register_type::<AnimationEntityLink>()
@@ -57,7 +57,7 @@ pub fn spawning_plugin(app: &mut App) {
     Default,
 )]
 #[reflect(Component, Serialize, Deserialize)]
-pub enum GameObject {
+pub(crate) enum GameObject {
     #[default]
     Empty,
     Box,

--- a/src/level_instantiation/spawning/animation_link.rs
+++ b/src/level_instantiation/spawning/animation_link.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct AnimationEntityLink(pub Entity);
+pub(crate) struct AnimationEntityLink(pub(crate) Entity);
 
 impl Default for AnimationEntityLink {
     fn default() -> Self {
@@ -12,7 +12,7 @@ impl Default for AnimationEntityLink {
     }
 }
 
-pub fn link_animations(
+pub(crate) fn link_animations(
     player_query: Query<Entity, Added<AnimationPlayer>>,
     parent_query: Query<&Parent>,
     animations_entity_link_query: Query<&AnimationEntityLink>,

--- a/src/level_instantiation/spawning/despawn.rs
+++ b/src/level_instantiation/spawning/despawn.rs
@@ -3,11 +3,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Component, Clone, PartialEq, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Despawn {
-    pub recursive: bool,
+pub(crate) struct Despawn {
+    pub(crate) recursive: bool,
 }
 
-pub fn despawn(mut commands: Commands, despawn_query: Query<(Entity, &Despawn, &Children)>) {
+pub(crate) fn despawn(mut commands: Commands, despawn_query: Query<(Entity, &Despawn, &Children)>) {
     for (entity, despawn, children) in despawn_query.iter() {
         if despawn.recursive {
             commands.entity(entity).despawn_recursive();

--- a/src/level_instantiation/spawning/objects.rs
+++ b/src/level_instantiation/spawning/objects.rs
@@ -1,19 +1,19 @@
 use bevy_rapier3d::prelude::*;
 use bitflags::bitflags;
 
-pub mod camera;
-pub mod level;
-pub mod npc;
-pub mod orb;
-pub mod player;
-pub mod point_light;
-pub mod primitives;
-pub mod skydome;
-pub mod sunlight;
+pub(crate) mod camera;
+pub(crate) mod level;
+pub(crate) mod npc;
+pub(crate) mod orb;
+pub(crate) mod player;
+pub(crate) mod point_light;
+pub(crate) mod primitives;
+pub(crate) mod skydome;
+pub(crate) mod sunlight;
 mod util;
 
 bitflags! {
-    pub struct GameCollisionGroup: u32 {
+    pub(crate) struct GameCollisionGroup: u32 {
         const PLAYER = 1 << 0;
         const OTHER = 1 << 31;
 

--- a/src/level_instantiation/spawning/objects/level.rs
+++ b/src/level_instantiation/spawning/objects/level.rs
@@ -20,4 +20,4 @@ pub(crate) fn spawn(
 }
 
 #[derive(Component)]
-pub struct Imported;
+pub(crate) struct Imported;

--- a/src/level_instantiation/spawning/objects/npc.rs
+++ b/src/level_instantiation/spawning/objects/npc.rs
@@ -8,8 +8,8 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 use std::f32::consts::TAU;
 
-pub const HEIGHT: f32 = 0.4;
-pub const RADIUS: f32 = 0.4;
+pub(crate) const HEIGHT: f32 = 0.4;
+pub(crate) const RADIUS: f32 = 0.4;
 
 pub(crate) fn spawn(
     In(transform): In<Transform>,

--- a/src/level_instantiation/spawning/objects/player.rs
+++ b/src/level_instantiation/spawning/objects/player.rs
@@ -10,8 +10,8 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
 use std::f32::consts::TAU;
 
-pub const HEIGHT: f32 = 0.4;
-pub const RADIUS: f32 = 0.3;
+pub(crate) const HEIGHT: f32 = 0.4;
+pub(crate) const RADIUS: f32 = 0.3;
 
 pub(crate) fn spawn(
     In(transform): In<Transform>,

--- a/src/level_instantiation/spawning/objects/skydome.rs
+++ b/src/level_instantiation/spawning/objects/skydome.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Component, Clone, Copy, Serialize, Deserialize, Reflect, FromReflect, Default)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Skydome;
+pub(crate) struct Skydome;
 
 fn get_or_add_mesh_handle(mesh_assets: &mut Assets<Mesh>) -> Handle<Mesh> {
     const MESH_HANDLE: HandleUntyped =

--- a/src/level_instantiation/spawning/objects/util.rs
+++ b/src/level_instantiation/spawning/objects/util.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-pub trait MeshAssetsExt {
+pub(crate) trait MeshAssetsExt {
     fn get_or_add(&mut self, handle: HandleUntyped, create_mesh: impl Fn() -> Mesh)
         -> Handle<Mesh>;
 }

--- a/src/level_instantiation/spawning/post_spawn_modification.rs
+++ b/src/level_instantiation/spawning/post_spawn_modification.rs
@@ -7,7 +7,7 @@ use bevy_mod_sysfail::macros::*;
 use regex::Regex;
 use std::sync::LazyLock;
 
-pub fn set_hidden(mut added_name: Query<(&Name, &mut Visibility), Added<Name>>) {
+pub(crate) fn set_hidden(mut added_name: Query<(&Name, &mut Visibility), Added<Name>>) {
     #[cfg(feature = "tracing")]
     let _span = info_span!("set_hidden").entered();
     for (name, mut visibility) in added_name.iter_mut() {
@@ -17,7 +17,7 @@ pub fn set_hidden(mut added_name: Query<(&Name, &mut Visibility), Added<Name>>) 
     }
 }
 
-pub fn despawn_removed(
+pub(crate) fn despawn_removed(
     mut commands: Commands,
     mut added_name: Query<(Entity, &Name), Added<Name>>,
 ) {
@@ -36,7 +36,7 @@ static COLOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[sysfail(log(level = "error"))]
-pub fn set_color(
+pub(crate) fn set_color(
     added_name: Query<(&Name, &Children), Added<Name>>,
     material_handles: Query<&Handle<StandardMaterial>>,
     mut standard_materials: ResMut<Assets<StandardMaterial>>,
@@ -79,7 +79,7 @@ pub fn set_color(
 }
 
 #[sysfail(log(level = "error"))]
-pub fn set_shadows(
+pub(crate) fn set_shadows(
     mut commands: Commands,
     added_mesh: Query<Entity, Added<Handle<Mesh>>>,
     parent_query: Query<&Parent>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,20 +15,20 @@
 //! Instead, decide for yourself which features you like and which one's you don't and simply trim the code accordingly.
 //! Feel free to [file an issue](https://github.com/janhohenheim/foxtrot/issues/new) if you need help!
 //! The docs are organized such that you can click through the plugins to explore the systems at play.
-pub mod bevy_config;
+pub(crate) mod bevy_config;
 #[cfg(feature = "dev")]
-pub mod dev;
-pub mod file_system_interaction;
-pub mod ingame_menu;
-pub mod level_instantiation;
-pub mod menu;
-pub mod movement;
+pub(crate) mod dev;
+pub(crate) mod file_system_interaction;
+pub(crate) mod ingame_menu;
+pub(crate) mod level_instantiation;
+pub(crate) mod menu;
+pub(crate) mod movement;
 #[cfg(feature = "native")]
-pub mod particles;
-pub mod player_control;
-pub mod shader;
-pub mod util;
-pub mod world_interaction;
+pub(crate) mod particles;
+pub(crate) mod player_control;
+pub(crate) mod shader;
+pub(crate) mod util;
+pub(crate) mod world_interaction;
 
 use crate::bevy_config::bevy_config_plugin;
 #[cfg(feature = "dev")]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -7,7 +7,7 @@ use bevy_egui::{egui, EguiContexts};
 
 /// This plugin is responsible for the game menu
 /// The menu is only drawn during the State `GameState::Menu` and is removed when that state is exited.
-pub fn menu_plugin(app: &mut App) {
+pub(crate) fn menu_plugin(app: &mut App) {
     app.add_system(setup_menu.in_set(OnUpdate(GameState::Menu)));
 }
 

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,6 +1,6 @@
-pub mod general_movement;
-pub mod navigation;
-pub mod physics;
+pub(crate) mod general_movement;
+pub(crate) mod navigation;
+pub(crate) mod physics;
 
 use crate::movement::general_movement::general_movement_plugin;
 use crate::movement::navigation::navigation_plugin;
@@ -15,7 +15,7 @@ use seldom_fn_plugin::FnPluginExt;
 /// this sense is anything that behaves in a not-quite completely physical way, like a player, an npc, an elevator, a moving platform, etc.
 /// Contrast this with pure rigidbodies like a ball, a crate, etc.
 /// - [`navigation_plugin`]: Handles npc pathfinding via bevy_pathmesh integration.
-pub fn movement_plugin(app: &mut App) {
+pub(crate) fn movement_plugin(app: &mut App) {
     app.fn_plugin(physics_plugin)
         .fn_plugin(general_movement_plugin)
         .fn_plugin(navigation_plugin);

--- a/src/movement/general_movement.rs
+++ b/src/movement/general_movement.rs
@@ -10,7 +10,7 @@ use crate::util::smoothness_to_lerp_factor;
 use crate::util::trait_extension::{TransformExt, Vec3Ext};
 use crate::GameState;
 use bevy_mod_sysfail::macros::*;
-pub use components::*;
+pub(crate) use components::*;
 
 /// Handles movement of character controllers, i.e. entities with the [`CharacterControllerBundle`].
 /// The default forces on a character going right are:  
@@ -34,7 +34,7 @@ pub use components::*;
 /// - An instantaneous force (i.e. an impulse) like jumping: `external_impulse.impulse += velocity * read_mass_properties.0.mass`, with `external_impulse`: [`ExternalImpulse`], `read_mass_properties`: [`ReadMassProperties`], and a user-defined `velocity`: [`Vec3`]
 ///
 /// Note: you might notice that the normal force is not included in the above diagram. This is because rapier emulates it by moving penetrating colliders out of each other.
-pub fn general_movement_plugin(app: &mut App) {
+pub(crate) fn general_movement_plugin(app: &mut App) {
     app.register_type::<Grounded>()
         .register_type::<Jumping>()
         .register_type::<Velocity>()
@@ -58,7 +58,7 @@ pub fn general_movement_plugin(app: &mut App) {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub struct GeneralMovementSystemSet;
+pub(crate) struct GeneralMovementSystemSet;
 
 fn update_grounded(
     mut query: Query<(Entity, &Transform, &Collider, &mut Grounded)>,
@@ -82,7 +82,7 @@ fn update_grounded(
     }
 }
 
-pub fn reset_forces_and_impulses(
+pub(crate) fn reset_forces_and_impulses(
     mut forces: Query<&mut ExternalForce>,
     mut impulses: Query<&mut ExternalImpulse>,
 ) {
@@ -96,7 +96,7 @@ pub fn reset_forces_and_impulses(
     }
 }
 
-pub fn reset_movement_components(
+pub(crate) fn reset_movement_components(
     mut walking: Query<&mut Walking>,
     mut jumpers: Query<&mut Jumping>,
 ) {
@@ -110,7 +110,7 @@ pub fn reset_movement_components(
     }
 }
 
-pub fn apply_jumping(
+pub(crate) fn apply_jumping(
     mut character_query: Query<(
         &Grounded,
         &mut ExternalImpulse,
@@ -200,7 +200,7 @@ fn play_animations(
     Ok(())
 }
 
-pub fn apply_walking(
+pub(crate) fn apply_walking(
     mut character_query: Query<(
         &mut ExternalForce,
         &Walking,

--- a/src/movement/general_movement/components.rs
+++ b/src/movement/general_movement/components.rs
@@ -3,21 +3,21 @@ use bevy_rapier3d::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Bundle)]
-pub struct CharacterControllerBundle {
-    pub gravity_scale: GravityScale,
-    pub mass: ColliderMassProperties,
-    pub read_mass: ReadMassProperties,
-    pub walking: Walking,
-    pub jumping: Jumping,
-    pub grounded: Grounded,
-    pub damping: Damping,
-    pub rigid_body: RigidBody,
-    pub locked_axes: LockedAxes,
-    pub collider: Collider,
-    pub force: ExternalForce,
-    pub impulse: ExternalImpulse,
-    pub velocity: Velocity,
-    pub dominance: Dominance,
+pub(crate) struct CharacterControllerBundle {
+    pub(crate) gravity_scale: GravityScale,
+    pub(crate) mass: ColliderMassProperties,
+    pub(crate) read_mass: ReadMassProperties,
+    pub(crate) walking: Walking,
+    pub(crate) jumping: Jumping,
+    pub(crate) grounded: Grounded,
+    pub(crate) damping: Damping,
+    pub(crate) rigid_body: RigidBody,
+    pub(crate) locked_axes: LockedAxes,
+    pub(crate) collider: Collider,
+    pub(crate) force: ExternalForce,
+    pub(crate) impulse: ExternalImpulse,
+    pub(crate) velocity: Velocity,
+    pub(crate) dominance: Dominance,
 }
 
 impl Default for CharacterControllerBundle {
@@ -45,7 +45,7 @@ impl Default for CharacterControllerBundle {
 }
 
 impl CharacterControllerBundle {
-    pub fn capsule(height: f32, radius: f32) -> Self {
+    pub(crate) fn capsule(height: f32, radius: f32) -> Self {
         Self {
             collider: Collider::capsule_y(height / 2., radius),
             ..default()
@@ -54,31 +54,31 @@ impl CharacterControllerBundle {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Serialize, Deserialize)]
-pub struct Model {
+pub(crate) struct Model {
     pub(crate) target: Entity,
 }
 
 #[derive(Debug, Clone, PartialEq, Component, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Walking {
+pub(crate) struct Walking {
     /// Acceleration on the ground
-    pub ground_acceleration: f32,
+    pub(crate) ground_acceleration: f32,
     /// Acceleration on the ground when[`Walking::sprinting`] is `true`
-    pub sprinting_acceleration: f32,
+    pub(crate) sprinting_acceleration: f32,
     /// Acceleration in the air
-    pub aerial_acceleration: f32,
+    pub(crate) aerial_acceleration: f32,
     /// Acceleration in opposide direction of velocity when not explicitely walking, i.e. [`Walking::direction`] is [`Option::None`]
-    pub braking_acceleration: f32,
+    pub(crate) braking_acceleration: f32,
     /// Speed at which we stop braking and just set the horizontal velocity to 0
-    pub stopping_speed: f32,
+    pub(crate) stopping_speed: f32,
     /// Direction in which we want to walk this tick. When not normalized, the acceleration will be scaled accordingly.
-    pub direction: Option<Vec3>,
+    pub(crate) direction: Option<Vec3>,
     /// Whether we are sprinting this tick
-    pub sprinting: bool,
+    pub(crate) sprinting: bool,
 }
 
 impl Walking {
-    pub fn get_acceleration(&self, grounded: bool) -> Option<Vec3> {
+    pub(crate) fn get_acceleration(&self, grounded: bool) -> Option<Vec3> {
         let acceleration = if grounded {
             if self.sprinting {
                 self.sprinting_acceleration
@@ -108,15 +108,15 @@ impl Default for Walking {
 
 #[derive(Debug, Clone, PartialEq, Component, Reflect, Default, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Grounded(pub bool);
+pub(crate) struct Grounded(pub(crate) bool);
 
 #[derive(Debug, Clone, PartialEq, Component, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Jumping {
+pub(crate) struct Jumping {
     /// Speed of the jump in m/s
-    pub speed: f32,
+    pub(crate) speed: f32,
     /// Was jump requested?
-    pub requested: bool,
+    pub(crate) requested: bool,
 }
 
 impl Default for Jumping {
@@ -130,8 +130,8 @@ impl Default for Jumping {
 
 #[derive(Debug, Clone, PartialEq, Component, Reflect, Default)]
 #[reflect(Component)]
-pub struct CharacterAnimations {
-    pub idle: Handle<AnimationClip>,
-    pub walk: Handle<AnimationClip>,
-    pub aerial: Handle<AnimationClip>,
+pub(crate) struct CharacterAnimations {
+    pub(crate) idle: Handle<AnimationClip>,
+    pub(crate) walk: Handle<AnimationClip>,
+    pub(crate) aerial: Handle<AnimationClip>,
 }

--- a/src/movement/navigation.rs
+++ b/src/movement/navigation.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 const CELL_WIDTH: f32 = 0.4 * npc::RADIUS;
 
 /// Handles NPC pathfinding. Currently, all entities with the [`Follower`] component will follow the [`Player`].
-pub fn navigation_plugin(app: &mut App) {
+pub(crate) fn navigation_plugin(app: &mut App) {
     app.add_plugin(OxidizedNavigationPlugin)
         // consts manually tweaked
         .insert_resource(NavMeshSettings {
@@ -49,7 +49,7 @@ pub fn navigation_plugin(app: &mut App) {
 
 #[derive(Debug, Component, Clone, PartialEq, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Follower;
+pub(crate) struct Follower;
 
 #[sysfail(log(level = "error"))]
 fn query_mesh(

--- a/src/movement/navigation/navmesh.rs
+++ b/src/movement/navigation/navmesh.rs
@@ -4,7 +4,7 @@ use bevy_pathmesh::PathMesh;
 #[cfg(feature = "dev")]
 use serde::{Deserialize, Serialize};
 
-pub fn read_navmesh(
+pub(crate) fn read_navmesh(
     mut commands: Commands,
     added_name: Query<(Entity, &Name, &GlobalTransform), Added<Name>>,
     children: Query<&Children>,
@@ -38,4 +38,4 @@ pub fn read_navmesh(
 #[cfg(feature = "dev")]
 #[derive(Debug, Component, Clone, PartialEq, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct NavMesh;
+pub(crate) struct NavMesh;

--- a/src/movement/physics.rs
+++ b/src/movement/physics.rs
@@ -7,7 +7,7 @@ use bevy_rapier3d::prelude::*;
 use oxidized_navigation::NavMeshAffector;
 
 /// Sets up the [`RapierPhysicsPlugin`] and [`RapierConfiguration`].
-pub fn physics_plugin(app: &mut App) {
+pub(crate) fn physics_plugin(app: &mut App) {
     app.add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         .insert_resource(RapierConfiguration {
             timestep_mode: TimestepMode::Variable {
@@ -21,7 +21,7 @@ pub fn physics_plugin(app: &mut App) {
 }
 
 #[sysfail(log(level = "error"))]
-pub fn read_colliders(
+pub(crate) fn read_colliders(
     mut commands: Commands,
     added_name: Query<(Entity, &Name), Added<Name>>,
     children: Query<&Children>,

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -11,7 +11,7 @@ use bevy_rapier3d::prelude::*;
 mod init;
 
 /// Handles particle effects instantiation and playing.
-pub fn particle_plugin(app: &mut App) {
+pub(crate) fn particle_plugin(app: &mut App) {
     app.register_type::<SprintingParticle>()
         .add_plugin(HanabiPlugin)
         .add_system(init_effects.in_schedule(OnExit(GameState::Loading)))

--- a/src/particles/init.rs
+++ b/src/particles/init.rs
@@ -4,7 +4,7 @@ use bevy::pbr::NotShadowReceiver;
 use bevy::prelude::*;
 use bevy_hanabi::prelude::*;
 
-pub fn init_effects(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
+pub(crate) fn init_effects(mut commands: Commands, mut effects: ResMut<Assets<EffectAsset>>) {
     let sprinting = create_sprinting_effect(&mut effects);
     commands.spawn((
         Name::new("Sprinting particle"),

--- a/src/player_control.rs
+++ b/src/player_control.rs
@@ -1,10 +1,10 @@
-pub mod actions;
-pub mod camera;
-pub mod player_embodiment;
+pub(crate) mod actions;
+pub(crate) mod camera;
+pub(crate) mod player_embodiment;
 
-pub use crate::player_control::actions::actions_plugin;
-pub use crate::player_control::camera::camera_plugin;
-pub use crate::player_control::player_embodiment::player_embodiment_plugin;
+pub(crate) use crate::player_control::actions::actions_plugin;
+pub(crate) use crate::player_control::camera::camera_plugin;
+pub(crate) use crate::player_control::player_embodiment::player_embodiment_plugin;
 use bevy::prelude::*;
 use seldom_fn_plugin::FnPluginExt;
 
@@ -13,7 +13,7 @@ use seldom_fn_plugin::FnPluginExt;
 /// - [`camera_plugin`]: Handles camera movement.
 /// - [`player_embodiment_plugin`]: Tells the components from [`super::movement_plugin`] about the desired player [`actions::Actions`].
 /// Also handles other systems that change how the player is physically represented in the world.
-pub fn player_control_plugin(app: &mut App) {
+pub(crate) fn player_control_plugin(app: &mut App) {
     app.fn_plugin(actions_plugin)
         .fn_plugin(camera_plugin)
         .fn_plugin(player_embodiment_plugin);

--- a/src/player_control/actions.rs
+++ b/src/player_control/actions.rs
@@ -7,17 +7,17 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Resource, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Resource, Serialize, Deserialize)]
-pub struct ActionsFrozen {
+pub(crate) struct ActionsFrozen {
     freeze_count: usize,
 }
 impl ActionsFrozen {
-    pub fn freeze(&mut self) {
+    pub(crate) fn freeze(&mut self) {
         self.freeze_count += 1;
     }
-    pub fn unfreeze(&mut self) {
+    pub(crate) fn unfreeze(&mut self) {
         self.freeze_count -= 1;
     }
-    pub fn is_frozen(&self) -> bool {
+    pub(crate) fn is_frozen(&self) -> bool {
         self.freeze_count > 0
     }
 }
@@ -25,7 +25,7 @@ impl ActionsFrozen {
 /// Configures [`Actions`], the resource that holds all player input.
 /// Add new input in [`set_actions`] and in [`game_control::generate_bindings!`](game_control).
 
-pub fn actions_plugin(app: &mut App) {
+pub(crate) fn actions_plugin(app: &mut App) {
     app.register_type::<PlayerAction>()
         .register_type::<CameraAction>()
         .register_type::<UiAction>()
@@ -43,7 +43,7 @@ pub fn actions_plugin(app: &mut App) {
 }
 
 #[derive(Debug, Clone, Copy, Actionlike, Reflect, FromReflect, Default)]
-pub enum PlayerAction {
+pub(crate) enum PlayerAction {
     #[default]
     Move,
     Sprint,
@@ -63,7 +63,7 @@ pub enum PlayerAction {
 }
 
 impl PlayerAction {
-    pub fn numbered_choice(index: u8) -> Self {
+    pub(crate) fn numbered_choice(index: u8) -> Self {
         match index {
             0 => PlayerAction::NumberedChoice0,
             1 => PlayerAction::NumberedChoice1,
@@ -84,19 +84,19 @@ impl PlayerAction {
 }
 
 #[derive(Debug, Clone, Actionlike, Reflect, FromReflect, Default)]
-pub enum CameraAction {
+pub(crate) enum CameraAction {
     #[default]
     Orbit,
     Zoom,
 }
 
 #[derive(Debug, Clone, Actionlike, Reflect, FromReflect, Default)]
-pub enum UiAction {
+pub(crate) enum UiAction {
     #[default]
     TogglePause,
 }
 
-pub fn create_player_action_input_manager_bundle() -> InputManagerBundle<PlayerAction> {
+pub(crate) fn create_player_action_input_manager_bundle() -> InputManagerBundle<PlayerAction> {
     InputManagerBundle {
         input_map: InputMap::new([
             (QwertyScanCode::Space, PlayerAction::Jump),
@@ -120,7 +120,7 @@ pub fn create_player_action_input_manager_bundle() -> InputManagerBundle<PlayerA
     }
 }
 
-pub fn create_camera_action_input_manager_bundle() -> InputManagerBundle<CameraAction> {
+pub(crate) fn create_camera_action_input_manager_bundle() -> InputManagerBundle<CameraAction> {
     InputManagerBundle {
         input_map: InputMap::default()
             .insert(DualAxis::mouse_motion(), CameraAction::Orbit)
@@ -130,14 +130,14 @@ pub fn create_camera_action_input_manager_bundle() -> InputManagerBundle<CameraA
     }
 }
 
-pub fn create_ui_action_input_manager_bundle() -> InputManagerBundle<UiAction> {
+pub(crate) fn create_ui_action_input_manager_bundle() -> InputManagerBundle<UiAction> {
     InputManagerBundle {
         input_map: InputMap::new([(QwertyScanCode::Escape, UiAction::TogglePause)]),
         ..default()
     }
 }
 
-pub fn remove_actions_when_frozen(
+pub(crate) fn remove_actions_when_frozen(
     mut player_actions_query: Query<&mut ActionState<PlayerAction>>,
     mut camera_actions_query: Query<&mut ActionState<CameraAction>>,
 ) {
@@ -155,7 +155,7 @@ pub fn remove_actions_when_frozen(
     }
 }
 
-pub trait DualAxisDataExt {
+pub(crate) trait DualAxisDataExt {
     fn max_normalized(self) -> Option<Vec2>;
 }
 

--- a/src/player_control/camera.rs
+++ b/src/player_control/camera.rs
@@ -6,12 +6,12 @@ use crate::player_control::camera::{
 use crate::GameState;
 use bevy::prelude::*;
 use bevy_dolly::prelude::*;
-pub use cursor::ForceCursorGrabMode;
+pub(crate) use cursor::ForceCursorGrabMode;
 use serde::{Deserialize, Serialize};
 use ui::*;
 
 mod cursor;
-pub mod focus;
+pub(crate) mod focus;
 mod kind;
 mod rig;
 mod skydome;
@@ -19,11 +19,11 @@ mod ui;
 
 #[derive(Debug, Clone, PartialEq, Component, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct IngameCamera {
-    pub target: Transform,
-    pub secondary_target: Option<Transform>,
-    pub desired_distance: f32,
-    pub kind: IngameCameraKind,
+pub(crate) struct IngameCamera {
+    pub(crate) target: Transform,
+    pub(crate) secondary_target: Option<Transform>,
+    pub(crate) desired_distance: f32,
+    pub(crate) kind: IngameCameraKind,
 }
 
 impl Default for IngameCamera {
@@ -39,7 +39,7 @@ impl Default for IngameCamera {
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect, Serialize, Deserialize, Default)]
 #[reflect(Serialize, Deserialize)]
-pub enum IngameCameraKind {
+pub(crate) enum IngameCameraKind {
     #[default]
     ThirdPerson,
     FirstPerson,
@@ -49,7 +49,7 @@ pub enum IngameCameraKind {
 /// Handles the main ingame camera, i.e. not the UI camera in the menu.
 /// Cameras are controlled with [`CameraActions`]. Depending on the distance, a first person,
 /// third person or fixed angle camera is used.
-pub fn camera_plugin(app: &mut App) {
+pub(crate) fn camera_plugin(app: &mut App) {
     app.register_type::<UiCamera>()
         .register_type::<IngameCamera>()
         .register_type::<IngameCameraKind>()
@@ -73,4 +73,4 @@ pub fn camera_plugin(app: &mut App) {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub struct CameraUpdateSystemSet;
+pub(crate) struct CameraUpdateSystemSet;

--- a/src/player_control/camera/cursor.rs
+++ b/src/player_control/camera/cursor.rs
@@ -6,10 +6,10 @@ use bevy_mod_sysfail::macros::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Resource, Serialize, Deserialize, Default)]
-pub struct ForceCursorGrabMode(pub Option<CursorGrabMode>);
+pub(crate) struct ForceCursorGrabMode(pub(crate) Option<CursorGrabMode>);
 
 #[sysfail(log(level = "error"))]
-pub fn grab_cursor(
+pub(crate) fn grab_cursor(
     mut primary_windows: Query<&mut Window, With<PrimaryWindow>>,
     actions_frozen: Res<ActionsFrozen>,
     force_cursor_grab: Res<ForceCursorGrabMode>,

--- a/src/player_control/camera/focus.rs
+++ b/src/player_control/camera/focus.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use bevy_mod_sysfail::macros::*;
 
 #[sysfail(log(level = "error"))]
-pub fn set_camera_focus(
+pub(crate) fn set_camera_focus(
     mut camera_query: Query<&mut IngameCamera>,
     current_dialog: Option<Res<CurrentDialog>>,
     player_query: Query<&Transform, With<Player>>,

--- a/src/player_control/camera/kind.rs
+++ b/src/player_control/camera/kind.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use bevy_dolly::prelude::*;
 use leafwing_input_manager::prelude::*;
 
-pub fn update_kind(
+pub(crate) fn update_kind(
     mut camera_query: Query<(&mut IngameCamera, &ActionState<CameraAction>)>,
     config: Res<GameConfig>,
 ) {
@@ -41,7 +41,7 @@ pub fn update_kind(
     }
 }
 
-pub fn update_drivers(mut camera_query: Query<(&IngameCamera, &mut Rig)>) {
+pub(crate) fn update_drivers(mut camera_query: Query<(&IngameCamera, &mut Rig)>) {
     for (camera, mut rig) in camera_query.iter_mut() {
         match camera.kind {
             IngameCameraKind::ThirdPerson => set_third_person_drivers(&mut rig),

--- a/src/player_control/camera/rig.rs
+++ b/src/player_control/camera/rig.rs
@@ -13,7 +13,7 @@ use leafwing_input_manager::prelude::ActionState;
 mod arm;
 
 #[sysfail(log(level = "error"))]
-pub fn update_rig(
+pub(crate) fn update_rig(
     time: Res<Time>,
     mut camera_query: Query<(
         &mut IngameCamera,

--- a/src/player_control/camera/rig/arm.rs
+++ b/src/player_control/camera/rig/arm.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use bevy_dolly::prelude::*;
 use bevy_rapier3d::prelude::*;
 
-pub fn get_arm_distance(
+pub(crate) fn get_arm_distance(
     camera: &IngameCamera,
     transform: &Transform,
     rapier_context: &RapierContext,
@@ -24,7 +24,7 @@ pub fn get_arm_distance(
     }
 }
 
-pub fn get_zoom_smoothness(
+pub(crate) fn get_zoom_smoothness(
     config: &GameConfig,
     camera: &IngameCamera,
     rig: &Rig,
@@ -46,7 +46,7 @@ pub fn get_zoom_smoothness(
     }
 }
 
-pub fn set_arm(rig: &mut Rig, distance: f32, zoom_smoothness: f32, dt: f32) {
+pub(crate) fn set_arm(rig: &mut Rig, distance: f32, zoom_smoothness: f32, dt: f32) {
     let factor = smoothness_to_lerp_factor(zoom_smoothness, dt);
     let arm_length = &mut rig.driver_mut::<Arm>().offset.z;
     *arm_length = arm_length.lerp(distance, factor);

--- a/src/player_control/camera/skydome.rs
+++ b/src/player_control/camera/skydome.rs
@@ -2,7 +2,7 @@ use crate::level_instantiation::spawning::objects::skydome::Skydome;
 use crate::player_control::camera::IngameCamera;
 use bevy::prelude::*;
 
-pub fn move_skydome(
+pub(crate) fn move_skydome(
     camera_query: Query<&Transform, (With<IngameCamera>, Without<Skydome>)>,
     mut skydome_query: Query<&mut Transform, (Without<IngameCamera>, With<Skydome>)>,
 ) {

--- a/src/player_control/camera/ui.rs
+++ b/src/player_control/camera/ui.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct UiCamera;
+pub(crate) struct UiCamera;
 
-pub fn spawn_ui_camera(mut commands: Commands) {
+pub(crate) fn spawn_ui_camera(mut commands: Commands) {
     commands.spawn((Camera2dBundle::default(), UiCamera, Name::new("Camera")));
 }
 
-pub fn despawn_ui_camera(mut commands: Commands, query: Query<Entity, With<UiCamera>>) {
+pub(crate) fn despawn_ui_camera(mut commands: Commands, query: Query<Entity, With<UiCamera>>) {
     for entity in &query {
         commands.entity(entity).despawn_recursive();
     }

--- a/src/player_control/player_embodiment.rs
+++ b/src/player_control/player_embodiment.rs
@@ -18,7 +18,7 @@ use std::ops::DerefMut;
 
 /// This plugin handles everything that has to do with the player's physical representation in the world.
 /// This includes movement and rotation that differ from the way the [`MovementPlugin`] already handles characters in general.
-pub fn player_embodiment_plugin(app: &mut App) {
+pub(crate) fn player_embodiment_plugin(app: &mut App) {
     app.register_type::<Timer>()
         .register_type::<Player>()
         .add_systems(
@@ -39,7 +39,7 @@ pub fn player_embodiment_plugin(app: &mut App) {
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Component, Serialize, Deserialize)]
-pub struct Player;
+pub(crate) struct Player;
 
 fn handle_jump(mut player_query: Query<(&ActionState<PlayerAction>, &mut Jumping), With<Player>>) {
     #[cfg(feature = "tracing")]

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -19,7 +19,7 @@ use std::sync::LazyLock;
 /// Handles instantiation of shaders. The shaders can be found in the [`shaders`](https://github.com/janhohenheim/foxtrot/tree/main/assets/shaders) directory.
 /// Shaders are stored in [`Material`]s which can be used on objects by attaching a `Handle<Material>` to an entity.
 /// The handles can be stored and retrieved in the [`Materials`] resource.
-pub fn shader_plugin(app: &mut App) {
+pub(crate) fn shader_plugin(app: &mut App) {
     app.add_plugin(MaterialPlugin::<GlowyMaterial>::default())
         .add_plugin(MaterialPlugin::<RepeatedMaterial>::default())
         .add_plugin(MaterialPlugin::<SkydomeMaterial>::default())
@@ -28,11 +28,11 @@ pub fn shader_plugin(app: &mut App) {
 }
 
 #[derive(Resource, Debug, Clone)]
-pub struct Materials {
-    pub glowy: Handle<GlowyMaterial>,
+pub(crate) struct Materials {
+    pub(crate) glowy: Handle<GlowyMaterial>,
     /// (Texture asset ID, Repeats) -> RepeatedMaterial
-    pub repeated: HashMap<(HandleId, Repeats), Handle<RepeatedMaterial>>,
-    pub skydome: Handle<SkydomeMaterial>,
+    pub(crate) repeated: HashMap<(HandleId, Repeats), Handle<RepeatedMaterial>>,
+    pub(crate) skydome: Handle<SkydomeMaterial>,
 }
 
 fn setup_shader(
@@ -58,10 +58,10 @@ fn setup_shader(
 #[derive(AsBindGroup, Debug, Clone, TypeUuid)]
 #[uuid = "bd5c76fd-6fdd-4de4-9744-4e8beea8daaf"]
 /// Material for [`glowy.wgsl`](https://github.com/janhohenheim/foxtrot/blob/main/assets/shaders/glowy.wgsl).
-pub struct GlowyMaterial {
+pub(crate) struct GlowyMaterial {
     #[texture(0)]
     #[sampler(1)]
-    pub env_texture: Handle<Image>,
+    pub(crate) env_texture: Handle<Image>,
 }
 
 impl Material for GlowyMaterial {
@@ -73,10 +73,10 @@ impl Material for GlowyMaterial {
 #[derive(AsBindGroup, Debug, Clone, TypeUuid)]
 #[uuid = "8ca95d76-91d6-44c0-a67b-8a4d22cd59b1"]
 /// Material for [`skydome.wgsl`](https://github.com/janhohenheim/foxtrot/blob/main/assets/shaders/skydome.wgsl).
-pub struct SkydomeMaterial {
+pub(crate) struct SkydomeMaterial {
     #[texture(0)]
     #[sampler(1)]
-    pub env_texture: Handle<Image>,
+    pub(crate) env_texture: Handle<Image>,
 }
 
 impl Material for SkydomeMaterial {
@@ -97,22 +97,22 @@ impl Material for SkydomeMaterial {
 
 #[repr(C, align(16))] // All WebGPU uniforms must be aligned to 16 bytes
 #[derive(Clone, Copy, ShaderType, Debug, Hash, Eq, PartialEq, Default)]
-pub struct Repeats {
-    pub horizontal: u32,
-    pub vertical: u32,
-    pub _wasm_padding1: u32,
-    pub _wasm_padding2: u32,
+pub(crate) struct Repeats {
+    pub(crate) horizontal: u32,
+    pub(crate) vertical: u32,
+    pub(crate) _wasm_padding1: u32,
+    pub(crate) _wasm_padding2: u32,
 }
 
 #[derive(AsBindGroup, Debug, Clone, TypeUuid)]
 #[uuid = "82d336c5-fd6c-41a3-bdd4-267cd4c9be22"]
 /// Material for [`repeated.wgsl`](https://github.com/janhohenheim/foxtrot/blob/main/assets/shaders/repeated.wgsl).
-pub struct RepeatedMaterial {
+pub(crate) struct RepeatedMaterial {
     #[texture(0)]
     #[sampler(1)]
-    pub texture: Handle<Image>,
+    pub(crate) texture: Handle<Image>,
     #[uniform(2)]
-    pub repeats: Repeats,
+    pub(crate) repeats: Repeats,
 }
 
 impl Material for RepeatedMaterial {
@@ -126,7 +126,7 @@ static REPEAT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[sysfail(log(level = "error"))]
-pub fn set_texture_to_repeat(
+pub(crate) fn set_texture_to_repeat(
     mut commands: Commands,
     added_name: Query<(&Name, &Children), Added<Name>>,
     material_handles: Query<&Handle<StandardMaterial>>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
-pub mod criteria;
-pub mod trait_extension;
+pub(crate) mod criteria;
+pub(crate) mod trait_extension;
 
-pub fn smoothness_to_lerp_factor(smoothness: f32, dt: f32) -> f32 {
+pub(crate) fn smoothness_to_lerp_factor(smoothness: f32, dt: f32) -> f32 {
     // Taken from https://github.com/h3r2tic/dolly/blob/main/src/util.rs#L34
     const SMOOTHNESS_MULTIPLIER: f32 = 8.0;
     1.0 - (-SMOOTHNESS_MULTIPLIER * dt / smoothness.max(1e-5)).exp()

--- a/src/util/criteria.rs
+++ b/src/util/criteria.rs
@@ -1,11 +1,11 @@
 use crate::player_control::actions::ActionsFrozen;
 use bevy::prelude::*;
 
-pub fn is_frozen(actions_frozen: Res<ActionsFrozen>) -> bool {
+pub(crate) fn is_frozen(actions_frozen: Res<ActionsFrozen>) -> bool {
     actions_frozen.is_frozen()
 }
 
 #[allow(unused)]
-pub fn never() -> bool {
+pub(crate) fn never() -> bool {
     false
 }

--- a/src/util/trait_extension.rs
+++ b/src/util/trait_extension.rs
@@ -28,12 +28,6 @@ pub(crate) struct SplitVec3 {
     pub(crate) horizontal: Vec3,
 }
 
-impl SplitVec3 {
-    pub(crate) fn as_array(self) -> [Vec3; 2] {
-        [self.vertical, self.horizontal]
-    }
-}
-
 pub(crate) trait Vec2Ext: Copy {
     fn is_approx_zero(self) -> bool;
     fn x0y(self) -> Vec3;

--- a/src/util/trait_extension.rs
+++ b/src/util/trait_extension.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::render::mesh::{MeshVertexAttributeId, PrimitiveTopology, VertexAttributeValues};
 
-pub trait Vec3Ext: Copy {
+pub(crate) trait Vec3Ext: Copy {
     fn is_approx_zero(self) -> bool;
     fn split(self, up: Vec3) -> SplitVec3;
 }
@@ -23,18 +23,18 @@ impl Vec3Ext for Vec3 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SplitVec3 {
-    pub vertical: Vec3,
-    pub horizontal: Vec3,
+pub(crate) struct SplitVec3 {
+    pub(crate) vertical: Vec3,
+    pub(crate) horizontal: Vec3,
 }
 
 impl SplitVec3 {
-    pub fn as_array(self) -> [Vec3; 2] {
+    pub(crate) fn as_array(self) -> [Vec3; 2] {
         [self.vertical, self.horizontal]
     }
 }
 
-pub trait Vec2Ext: Copy {
+pub(crate) trait Vec2Ext: Copy {
     fn is_approx_zero(self) -> bool;
     fn x0y(self) -> Vec3;
 }
@@ -50,7 +50,7 @@ impl Vec2Ext for Vec2 {
     }
 }
 
-pub trait MeshExt {
+pub(crate) trait MeshExt {
     fn transform(&mut self, transform: Transform);
     fn transformed(&self, transform: Transform) -> Mesh;
     fn read_coords_mut(&mut self, id: impl Into<MeshVertexAttributeId>) -> &mut Vec<[f32; 3]>;
@@ -131,7 +131,7 @@ impl MeshExt for Mesh {
     }
 }
 
-pub trait F32Ext: Copy {
+pub(crate) trait F32Ext: Copy {
     fn is_approx_zero(self) -> bool;
     fn squared(self) -> f32;
     fn lerp(self, other: f32, ratio: f32) -> f32;
@@ -154,7 +154,7 @@ impl F32Ext for f32 {
     }
 }
 
-pub trait TransformExt: Copy {
+pub(crate) trait TransformExt: Copy {
     fn horizontally_looking_at(self, target: Vec3, up: Vec3) -> Transform;
     fn lerp(self, other: Transform, ratio: f32) -> Transform;
 }

--- a/src/world_interaction.rs
+++ b/src/world_interaction.rs
@@ -1,6 +1,6 @@
-pub mod condition;
-pub mod dialog;
-pub mod interactions_ui;
+pub(crate) mod condition;
+pub(crate) mod dialog;
+pub(crate) mod interactions_ui;
 
 use crate::world_interaction::condition::condition_plugin;
 use crate::world_interaction::dialog::dialog_plugin;
@@ -12,7 +12,7 @@ use seldom_fn_plugin::FnPluginExt;
 /// - [`condition_plugin`] handles trackers of player actions such as chosen dialog options
 /// - [`dialog_plugin`] handles dialog trees
 /// - [`interactions_ui_plugin`] handles the UI for interacting with an object in front of the player.
-pub fn world_interaction_plugin(app: &mut App) {
+pub(crate) fn world_interaction_plugin(app: &mut App) {
     app.fn_plugin(condition_plugin)
         .fn_plugin(dialog_plugin)
         .fn_plugin(interactions_ui_plugin);

--- a/src/world_interaction/condition.rs
+++ b/src/world_interaction/condition.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy::utils::HashSet;
 use serde::{Deserialize, Serialize};
 
-pub fn condition_plugin(app: &mut App) {
+pub(crate) fn condition_plugin(app: &mut App) {
     app.init_resource::<ActiveConditions>()
         .add_event::<ConditionAddEvent>()
         .add_system(add_conditions.in_set(OnUpdate(GameState::Playing)));
@@ -11,9 +11,9 @@ pub fn condition_plugin(app: &mut App) {
 
 #[derive(Debug, Clone, Eq, PartialEq, Resource, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Resource, Serialize, Deserialize)]
-pub struct ActiveConditions(pub HashSet<ConditionId>);
+pub(crate) struct ActiveConditions(pub(crate) HashSet<ConditionId>);
 impl ActiveConditions {
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
@@ -23,7 +23,7 @@ impl ActiveConditions {
 )]
 #[reflect(Serialize, Deserialize)]
 #[serde(from = "String", into = "String")]
-pub struct ConditionId(pub String);
+pub(crate) struct ConditionId(pub(crate) String);
 
 impl From<String> for ConditionId {
     fn from(value: String) -> Self {
@@ -39,7 +39,7 @@ impl From<ConditionId> for String {
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, Reflect, Hash, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
-pub struct ConditionAddEvent(pub ConditionId);
+pub(crate) struct ConditionAddEvent(pub(crate) ConditionId);
 
 fn add_conditions(
     mut conditions: ResMut<ActiveConditions>,

--- a/src/world_interaction/dialog.rs
+++ b/src/world_interaction/dialog.rs
@@ -4,7 +4,7 @@ use crate::player_control::actions::{ActionsFrozen, PlayerAction};
 use crate::world_interaction::condition::{ActiveConditions, ConditionAddEvent, ConditionId};
 use crate::world_interaction::dialog::resources::Page;
 pub(crate) use crate::world_interaction::dialog::resources::{
-    CurrentDialog, Dialog, DialogEvent, DialogId, InitialPage, NextPage,
+    CurrentDialog, Dialog, DialogEvent, DialogId, NextPage,
 };
 use crate::GameState;
 use anyhow::{Context, Ok, Result};

--- a/src/world_interaction/dialog.rs
+++ b/src/world_interaction/dialog.rs
@@ -3,7 +3,7 @@ use crate::file_system_interaction::config::GameConfig;
 use crate::player_control::actions::{ActionsFrozen, PlayerAction};
 use crate::world_interaction::condition::{ActiveConditions, ConditionAddEvent, ConditionId};
 use crate::world_interaction::dialog::resources::Page;
-pub use crate::world_interaction::dialog::resources::{
+pub(crate) use crate::world_interaction::dialog::resources::{
     CurrentDialog, Dialog, DialogEvent, DialogId, InitialPage, NextPage,
 };
 use crate::GameState;
@@ -21,7 +21,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 mod resources;
 
-pub fn dialog_plugin(app: &mut App) {
+pub(crate) fn dialog_plugin(app: &mut App) {
     app.add_plugin(EguiPlugin)
         .register_type::<DialogId>()
         .add_event::<DialogEvent>()
@@ -29,8 +29,8 @@ pub fn dialog_plugin(app: &mut App) {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Serialize, Deserialize, Default)]
-pub struct DialogTarget {
-    pub dialog_id: DialogId,
+pub(crate) struct DialogTarget {
+    pub(crate) dialog_id: DialogId,
 }
 
 #[sysfail(log(level = "error"))]

--- a/src/world_interaction/dialog/resources.rs
+++ b/src/world_interaction/dialog/resources.rs
@@ -8,63 +8,63 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Serialize, Deserialize)]
-pub struct DialogEvent {
-    pub dialog: DialogId,
-    pub source: Entity,
-    pub page: Option<PageId>,
+pub(crate) struct DialogEvent {
+    pub(crate) dialog: DialogId,
+    pub(crate) source: Entity,
+    pub(crate) page: Option<PageId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Resource, Serialize, Deserialize)]
-pub struct CurrentDialog {
-    pub source: Entity,
-    pub id: DialogId,
-    pub dialog: Dialog,
-    pub current_page: PageId,
-    pub last_choice: Option<ConditionId>,
+pub(crate) struct CurrentDialog {
+    pub(crate) source: Entity,
+    pub(crate) id: DialogId,
+    pub(crate) dialog: Dialog,
+    pub(crate) current_page: PageId,
+    pub(crate) last_choice: Option<ConditionId>,
 }
 impl CurrentDialog {
-    pub fn fetch_page(&self, page_id: &PageId) -> Result<Page> {
+    pub(crate) fn fetch_page(&self, page_id: &PageId) -> Result<Page> {
         self.dialog
             .pages
             .get(page_id)
             .with_context(|| format!("Failed to fetch page with id {}", page_id.0))
             .cloned()
     }
-    pub fn fetch_current_page(&self) -> Result<Page> {
+    pub(crate) fn fetch_current_page(&self) -> Result<Page> {
         self.fetch_page(&self.current_page)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypeUuid, Default)]
 #[uuid = "f7c10043-7196-4ead-a4dd-040c33798a62"]
-pub struct Dialog {
-    pub initial_page: Vec<InitialPage>,
-    pub pages: HashMap<PageId, Page>,
+pub(crate) struct Dialog {
+    pub(crate) initial_page: Vec<InitialPage>,
+    pub(crate) pages: HashMap<PageId, Page>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Reflect, Serialize, Deserialize, Default, FromReflect)]
 #[reflect(Serialize, Deserialize)]
-pub struct InitialPage {
-    pub id: PageId,
+pub(crate) struct InitialPage {
+    pub(crate) id: PageId,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub positive_requirements: HashSet<ConditionId>,
+    pub(crate) positive_requirements: HashSet<ConditionId>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub negative_requirements: HashSet<ConditionId>,
+    pub(crate) negative_requirements: HashSet<ConditionId>,
 }
 
 impl InitialPage {
-    pub fn is_available(&self, active_conditions: &ActiveConditions) -> bool {
+    pub(crate) fn is_available(&self, active_conditions: &ActiveConditions) -> bool {
         self.positive_requirements.is_subset(&active_conditions.0)
             && self.negative_requirements.is_disjoint(&active_conditions.0)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Page {
-    pub text: String,
+pub(crate) struct Page {
+    pub(crate) text: String,
     #[serde(default = "get_default_talking_speed")]
-    pub talking_speed: f32,
-    pub next_page: NextPage,
+    pub(crate) talking_speed: f32,
+    pub(crate) next_page: NextPage,
 }
 
 fn get_default_talking_speed() -> f32 {
@@ -82,7 +82,7 @@ impl Default for Page {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum NextPage {
+pub(crate) enum NextPage {
     /// There is only one automatic option for the next page
     Continue(PageId),
     /// The user can choose between different answers that determine the next page
@@ -100,18 +100,18 @@ impl Default for NextPage {
 
 #[derive(Debug, Clone, Eq, PartialEq, Default, Reflect, Serialize, Deserialize, FromReflect)]
 #[reflect(Serialize, Deserialize)]
-pub struct DialogChoice {
+pub(crate) struct DialogChoice {
     /// The player's answer
-    pub text: String,
-    pub next_page_id: PageId,
+    pub(crate) text: String,
+    pub(crate) next_page_id: PageId,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub positive_requirements: HashSet<ConditionId>,
+    pub(crate) positive_requirements: HashSet<ConditionId>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
-    pub negative_requirements: HashSet<ConditionId>,
+    pub(crate) negative_requirements: HashSet<ConditionId>,
 }
 
 impl DialogChoice {
-    pub fn is_available(&self, active_conditions: &ActiveConditions) -> bool {
+    pub(crate) fn is_available(&self, active_conditions: &ActiveConditions) -> bool {
         self.positive_requirements.is_subset(&active_conditions.0)
             && self.negative_requirements.is_disjoint(&active_conditions.0)
     }
@@ -132,9 +132,9 @@ impl DialogChoice {
 )]
 #[reflect(Component, Serialize, Deserialize)]
 #[serde(from = "String", into = "String")]
-pub struct DialogId(pub String);
+pub(crate) struct DialogId(pub(crate) String);
 impl DialogId {
-    pub fn new(id: &str) -> Self {
+    pub(crate) fn new(id: &str) -> Self {
         Self(id.to_string())
     }
 }
@@ -156,7 +156,7 @@ impl From<DialogId> for String {
 )]
 #[reflect(Serialize, Deserialize)]
 #[serde(from = "String", into = "String")]
-pub struct PageId(pub String);
+pub(crate) struct PageId(pub(crate) String);
 
 impl From<String> for PageId {
     fn from(value: String) -> Self {

--- a/src/world_interaction/interactions_ui.rs
+++ b/src/world_interaction/interactions_ui.rs
@@ -15,7 +15,7 @@ use leafwing_input_manager::prelude::ActionState;
 use serde::{Deserialize, Serialize};
 use std::f32::consts::TAU;
 
-pub fn interactions_ui_plugin(app: &mut App) {
+pub(crate) fn interactions_ui_plugin(app: &mut App) {
     app.register_type::<InteractionOpportunities>()
         .init_resource::<InteractionOpportunities>()
         .add_systems(
@@ -31,13 +31,13 @@ pub fn interactions_ui_plugin(app: &mut App) {
 }
 
 #[derive(Resource, Debug)]
-pub struct InteractionUi {
+pub(crate) struct InteractionUi {
     source: Entity,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Resource, Reflect, Serialize, Deserialize, Default)]
 #[reflect(Resource, Serialize, Deserialize)]
-pub struct InteractionOpportunities(pub HashSet<Entity>);
+pub(crate) struct InteractionOpportunities(pub(crate) HashSet<Entity>);
 
 fn update_interaction_opportunities(
     mut collision_events: EventReader<CollisionEvent>,


### PR DESCRIPTION
Closes #253.

This PR find-and-replaces `pub` with `pub(crate)` (it's a lot).

It also fixes the dead code warnings that emerged from this change.

I recommend to review this by commit to make it a bit easier :)