### PR TITLE
Bump to bevy=0.10.1, bevy_asset_loader=0.15, oxidized_navigation=0.4, embed_resource=2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_loader"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118490c65031cecd6586e6b2cbd16f05bc161438dd0d30c42e307638eab7daba"
+checksum = "f32463c4be049c9535661f2debcd76a6ee7fc5c0e0c2335214bda671607ae7d9"
 dependencies = [
  "anyhow",
  "bevy",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_loader_derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac452d5861a4f9e69625b9a6d63a846dc9ee0e3c5ee32fe2d9c5b8cd59b916ba"
+checksum = "2921646f30d11ae14b85e4957242dcb98c37b748987b00b84473fcd390c561dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -462,7 +462,7 @@ dependencies = [
  "bevy",
  "ron",
  "serde",
- "toml 0.7.3",
+ "toml",
 ]
 
 [[package]]
@@ -1857,13 +1857,13 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "1.8.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62abb876c07e4754fae5c14cafa77937841f01740637e17d78dc04352f32a5e"
+checksum = "80663502655af01a2902dff3f06869330782267924bf1788410b74edcd93770a"
 dependencies = [
  "cc",
  "rustc_version",
- "toml 0.5.11",
+ "toml",
  "vswhom",
  "winreg",
 ]
@@ -3248,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "oxidized_navigation"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a059d95d7308243da096540ec82d9c96e40f4a71fe557c646194a0c39a60d6"
+checksum = "b1eceefa71438e972accd771c1c77c2840bcb6d6a3761b9fbb0f80ac1a2c06f6"
 dependencies = [
  "bevy",
  "bevy_rapier3d",
@@ -4104,15 +4104,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
@@ -4933,10 +4924,11 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
 dependencies = [
+ "cfg-if",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ wasm_dev = ["wasm", "dev"]
 tracing = ["bevy/trace_chrome"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.10.1", default-features = false }
 bevy_kira_audio = "0.15"
-bevy_asset_loader = { version = "0.15", features = ["progress_tracking"] }
+bevy_asset_loader = { version = "0.16", features = ["progress_tracking"] }
 bevy_common_assets = { version = "0.6", features = ["ron", "toml"] }
 bevy_egui = "0.20"
 serde = { version = "1", features = ["derive"] }
@@ -70,7 +70,7 @@ ron = "0.8"
 regex = "1"
 chrono = "0.4"
 glob = "0.3"
-oxidized_navigation = "0.3"
+oxidized_navigation = "0.4"
 bitflags = "2"
 iyes_progress = "0.8"
 unicode-segmentation = "1"
@@ -98,4 +98,4 @@ winit = { version = "0.28", default-features = false }
 image = { version = "0.24", default-features = false }
 
 [build-dependencies]
-embed-resource = "1.4"
+embed-resource = "2.1"

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,6 @@ fn main() {
     let target = env::var("TARGET").expect("Failed to read env var TARGET");
     if target.contains("windows") {
         // on windows we will set our game icon as icon for the executable
-        embed_resource::compile("build/windows/icon.rc");
+        embed_resource::compile("build/windows/icon.rc", embed_resource::NONE);
     }
 }

--- a/src/movement/physics.rs
+++ b/src/movement/physics.rs
@@ -41,7 +41,7 @@ pub(crate) fn read_colliders(
 
                 commands
                     .entity(collider_entity)
-                    .insert((rapier_collider, NavMeshAffector::default()));
+                    .insert((rapier_collider, NavMeshAffector));
             }
         }
     }


### PR DESCRIPTION
And their respective migrations