### PR TITLE
Enable Cargo's sparse registry for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly
+  # Sparse cargo registry for faster updates
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test-native:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,6 +6,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly
+  # Sparse cargo registry for faster updates
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   build-web:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ env:
 
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly
+  # Sparse cargo registry for faster updates
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 permissions:
   contents: write


### PR DESCRIPTION
Closes #260.

This PR enables Cargo's sparse registry which can speed up the dependency updates in some cases.

The also <https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html>.

Depends on #262 for fixing CI.