### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Jan Hohenheim <jan@hohenheim.ch>"]
 edition = "2021"
 name = "foxtrot"
 version = "0.2.0"
-license = "MIT OR  Apache-2.0"
+license = "MIT OR Apache-2.0"
 exclude = [
     "dist",
     "build",

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -14,7 +14,7 @@ pub(crate) fn dev_plugin(app: &mut App) {
     {
         app.add_plugin(EditorPlugin)
             .insert_resource(default_editor_controls())
-            .add_plugin(FrameTimeDiagnosticsPlugin::default())
+            .add_plugin(FrameTimeDiagnosticsPlugin)
             .add_plugin(DebugLinesPlugin::default())
             .fn_plugin(dev_editor_plugin)
             .add_plugin(LogDiagnosticsPlugin::filtered(vec![]))


### PR DESCRIPTION
This PR fixes Clippy CI errors, caused by calling `::default()` on a unit struct.

I also removed an extra space from the `license` key in `Cargo.toml`.
Not sure if this could cause problems, but better safe than sorry!