### PR TITLE
Tweak some settings according to feedback

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,21 +1,23 @@
 # NOTE: For maximum performance, build using a nightly compiler
 # If you are using rust stable, remove the `"-Z", "share-generics=y"` below.
 
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Z", "share-generics=y"]
+# Uncomment the following lines for better link time performance. Requires lld on Windows, zld on macOS and clang on Linux.
+
+# [target.x86_64-unknown-linux-gnu]
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Z", "share-generics=y"]
 
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Z", "share-generics=y"]
+# [target.x86_64-apple-darwin]
+# rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Z", "share-generics=y"]
 
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Z", "share-generics=y"]
+# [target.aarch64-apple-darwin]
+# rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Z", "share-generics=y"]
 
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe"
-rustflags = ["-Z", "share-generics=n"]
+# [target.x86_64-pc-windows-msvc]
+# linker = "rust-lld.exe"
+# rustflags = ["-Z", "share-generics=n"]
 
 # Enable only a small amount of optimization in debug mode
 [profile.dev]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,31 +4,38 @@
 # Uncomment the following lines for better link time performance. Requires lld on Windows, zld on macOS and clang on Linux.
 
 # [target.x86_64-unknown-linux-gnu]
+# Uncomment for better performance. Requires clang.
 # linker = "clang"
+
+# Uncomment instead of default rustflags for better performance. Requires lld.
 # rustflags = ["-C", "link-arg=-fuse-ld=lld", "-Z", "share-generics=y"]
+rustflags = ["-Z", "share-generics=y"]
 
-# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
-# `brew install michaeleisel/zld/zld`
-# [target.x86_64-apple-darwin]
+[target.x86_64-apple-darwin]
+# Uncomment instead of default rustflags for better performance. Requires zld via `brew install michaeleisel/zld/zld`
 # rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld", "-Z", "share-generics=y"]
+rustflags = ["-Z", "share-generics=y"]
 
-# [target.aarch64-apple-darwin]
+[target.aarch64-apple-darwin]
+# Uncomment instead of default rustflags for better performance. Requires zld via `brew install michaeleisel/zld/zld`
 # rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld", "-Z", "share-generics=y"]
+rustflags = ["-Z", "share-generics=y"]
 
-# [target.x86_64-pc-windows-msvc]
+[target.x86_64-pc-windows-msvc]
+# Uncommentfor better performance. Requires lld via `cargo install -f cargo-binutils` and `rustup component add llvm-tools-preview`
 # linker = "rust-lld.exe"
-# rustflags = ["-Z", "share-generics=n"]
+rustflags = ["-Z", "share-generics=n"]
 
-# Enable only a small amount of optimization in debug mode
+# Enable no optimization in debug mode.
 [profile.dev]
-opt-level = 1
+opt-level = 0
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
 # debug = 1
 
-# Enable high optimizations for dependencies (incl. Bevy), but not for our code:
+# Enable some optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]
-opt-level = 2
+opt-level = 1
 
 [profile.release]
 lto = "thin"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,14 +26,14 @@ rustflags = ["-Z", "share-generics=y"]
 # linker = "rust-lld.exe"
 rustflags = ["-Z", "share-generics=n"]
 
-# Enable no optimization in debug mode.
+# Enable no optimization in debug mode. You should probably bump this up for Wasm builds.
 [profile.dev]
 opt-level = 0
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
 # debug = 1
 
-# Enable some optimizations for dependencies (incl. Bevy), but not for our code:
+# Enable some optimizations for dependencies (incl. Bevy), but not for our code. You should probably bump this up for Wasm builds.
 [profile.dev.package."*"]
 opt-level = 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,21 +580,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_editor_pls"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99034d9955806eb10b02c61ecdef83d22d57071aa6acd530ae9ec2156e3b930b"
+checksum = "b6750134dae54c3799ecf6130d6590a33751fabd021d4b94300ae3da856dceff"
 dependencies = [
  "bevy",
  "bevy_editor_pls_core",
  "bevy_editor_pls_default_windows",
+ "bevy_framepace",
  "egui",
+ "egui-gizmo",
 ]
 
 [[package]]
 name = "bevy_editor_pls_core"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c250a522bc7568a47faf8e5eb6a94fd479b03bc6dc58fcfe01a2cb6c0735a6"
+checksum = "b460290aaf413da0668569e904da974f33ae8fecd11d9d14a36043fa2c44e000"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
@@ -604,14 +606,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_editor_pls_default_windows"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967a1dd8fe3a0672eeea32f4e7d19a446f7f28dba2a7ebcf7f4cd88b539c46ee"
+checksum = "2d7d2fe16e2bd47f6b8e5bab2d7d8da4975616e28b041cba658283cf1c66ba1f"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
  "bevy_editor_pls_core",
  "bevy_mod_debugdump",
+ "egui-gizmo",
  "indexmap",
  "opener",
  "pretty-type-name",
@@ -638,6 +641,16 @@ checksum = "c086ebdc1f5522787d63772943277cc74a279445fb65db4d58c2c5330654648e"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
+]
+
+[[package]]
+name = "bevy_framepace"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1825c5a485aa2a2ffd91cc1faa1f4d621c804a893ead88cafedbe1ed6c51d34"
+dependencies = [
+ "bevy",
+ "spin_sleep",
 ]
 
 [[package]]
@@ -815,7 +828,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6a1109d06fe947990db032e719e162414cf9bf7a478dcc52742f1c7136c42a"
 dependencies = [
- "glam",
+ "glam 0.23.0",
  "serde",
 ]
 
@@ -825,7 +838,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39106bc2ee21fce9496d2e15e0ba7925dff63e3eae10f7c1fc0094b56ad9f2bb"
 dependencies = [
- "glam",
+ "glam 0.23.0",
 ]
 
 [[package]]
@@ -930,7 +943,7 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
- "glam",
+ "glam 0.23.0",
  "once_cell",
  "parking_lot",
  "serde",
@@ -1832,6 +1845,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui-gizmo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c043f3afe520e62a91da97cf718314c36dfdc75be4557ff0caca9a488e2fa0"
+dependencies = [
+ "egui",
+ "glam 0.22.0",
+]
+
+[[package]]
 name = "egui_dock"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1899,7 @@ checksum = "e6591f13a63571c4821802eb5b10fd1155b1290bce87086440003841c8c3909b"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam",
+ "glam 0.23.0",
  "thiserror",
 ]
 
@@ -2185,6 +2208,12 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
@@ -2366,7 +2395,7 @@ version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd41d443f978bfa380a6dad58b62a08c43bcb960631f13e9d015b911eaf73588"
 dependencies = [
- "glam",
+ "glam 0.23.0",
  "once_cell",
 ]
 
@@ -2889,7 +2918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68d47bba83f9e2006d117a9a33af1524e655516b8919caac694427a6fb1e511"
 dependencies = [
  "approx",
- "glam",
+ "glam 0.23.0",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -3853,6 +3882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d5eb764aca85ec14d1b7c8d497d03ed119260391364ba9f70b9be9735eaf0f9"
 dependencies = [
  "bevy",
+]
+
+[[package]]
+name = "spin_sleep"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafa7900db085f4354dbc7025e25d7a839a14360ea13b5fc4fd717f2d3b23134"
+dependencies = [
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,44 +20,11 @@ categories = ["game-development"]
 homepage = "https://janhohenheim.github.io/foxtrot/"
 
 [features]
-default = ["native-dev"]
-
-core = [
-    "bevy/animation",
-    "bevy/bevy_asset",
-    "bevy/bevy_scene",
-    "bevy/bevy_winit",
-    "bevy/bevy_core_pipeline",
-    "bevy/bevy_pbr",
-    "bevy/bevy_gltf",
-    "bevy/bevy_render",
-    "bevy/bevy_sprite",
-    "bevy/bevy_text",
-    "bevy/bevy_ui",
-    "bevy/png",
-    "bevy/jpeg",
-    "bevy/hdr",
-    "bevy/zstd",
-    "bevy/x11",
-    "bevy/ktx2",
-    "bevy/tonemapping_luts",
-    "bevy/serialize",
-]
-
-dev = ["dep:bevy_editor_pls", "dep:bevy_prototype_debug_lines", "core"]
-
-native-dev = ["bevy/bevy_dylib", "bevy/filesystem_watcher", "dev", "native"]
-
-native = ["bevy_rapier3d/parallel", "dep:bevy_hanabi", "core"]
-
-wasm = ["bevy_rapier3d/wasm-bindgen", "core", "dep:wasm-bindgen"]
-
-wasm_dev = ["wasm", "dev"]
-
+default = ["dev"]
+dev = ["dep:bevy_editor_pls", "dep:bevy_prototype_debug_lines"]
 tracing = ["bevy/trace_chrome"]
 
 [dependencies]
-bevy = { version = "0.10.1", default-features = false }
 bevy_kira_audio = "0.15"
 bevy_asset_loader = { version = "0.16", features = ["progress_tracking"] }
 bevy_common_assets = { version = "0.6", features = ["ron", "toml"] }
@@ -74,28 +41,65 @@ oxidized_navigation = "0.4"
 bitflags = "2"
 iyes_progress = "0.8"
 unicode-segmentation = "1"
-bevy_hanabi = { version = "0.6", optional = true }
 anyhow = "1"
-bevy_rapier3d = { version = "0.21", features = [
-    "serde-serialize",
-    "simd-nightly",
-] }
 leafwing-input-manager = { version = "0.9", features = ["egui"] }
-bevy_editor_pls = { version = "0.3", optional = true }
-bevy_prototype_debug_lines = { version = "0.10", optional = true, features = [
-    "3d",
-] }
-wasm-bindgen = { version = "0.2", optional = true }
 warbler_grass = "0.3"
 rand = { version = "0.8", features = ["small_rng", "nightly"] }
 bevy_dolly = { git = "https://github.com/BlackPhlox/bevy_dolly", rev = "b2f5dc787664cb8c3d92f792cbd437886fc090c6" }
 spew = "0.2.1"
 bevy_mod_sysfail = "2"
 seldom_fn_plugin = "0.3"
+bevy_rapier3d = { version = "0.21", features = [ "serde-serialize", "simd-nightly",] }
+bevy_editor_pls = { version = "0.4", optional = true }
+bevy_prototype_debug_lines = { version = "0.10", optional = true, features = [ "3d" ] }
 
 # keep the following in sync with Bevy's dependencies
 winit = { version = "0.28", default-features = false }
 image = { version = "0.24", default-features = false }
+
+[dependencies.bevy]
+version = "0.10.1"
+default-features = false
+features = [
+    "animation",
+    "bevy_asset",
+    "bevy_scene",
+    "bevy_winit",
+    "bevy_core_pipeline",
+    "bevy_pbr",
+    "bevy_gltf",
+    "bevy_render",
+    "bevy_sprite",
+    "bevy_text",
+    "bevy_ui",
+    "png",
+    "jpeg",
+    "hdr",
+    "zstd",
+    "x11",
+    "ktx2",
+    "tonemapping_luts",
+    "serialize",
+]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.bevy]
+version = "0.10.1"
+default-features = false
+features = [ "filesystem_watcher" ]
+
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.bevy]
+version = "0.10.1"
+default-features = false
+features = [ "bevy_dylib" ]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bevy_hanabi = "0.6"
+bevy_rapier3d = { version = "0.21", features = ["parallel"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+bevy_rapier3d = { version = "0.21", features = ["wasm-bindgen"] }
 
 [build-dependencies]
 embed-resource = "2.1"

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/9047632/226387411-70f662de-0681-47ff-b
 - Physics via [`bevy_rapier`](https://crates.io/crates/bevy_rapier)
 - Audio via [`bevy_kira_audio`](https://crates.io/crates/bevy_kira_audio)
 - Pathfinding via [`oxidized_navigation`](https://crates.io/crates/oxidized_navigation)
-- [`bevy_editor_pls`](https://crates.io/crates/bevy_editor_pls) in the `dev` feature, bound to 'Q'
+- [`bevy_editor_pls`](https://crates.io/crates/bevy_editor_pls) in the `dev` feature, bound to 'G'
 - Custom editor for the game state found in the windows selection for `bevy_editor_pls`.
 - Saving / loading levels
 - Saving / loading the game state
@@ -44,19 +44,6 @@ Wasm:
 ```bash
 trunk serve --no-default-features --features wasm_dev
 ```
-
-Building in general requires setting up LLD or ZLD as described in the [Bevy book](https://bevyengine.org/learn/book/getting-started/setup/#enable-fast-compiles-optional).
-Don't worry, it's super easy:
-- **Ubuntu**: `sudo apt-get install lld`
-- **Arch**: `sudo pacman -S lld`
-- **Windows**: Ensure you have the latest [cargo-binutils](https://github.com/rust-embedded/cargo-binutils)
-
-    ```sh
-    cargo install -f cargo-binutils
-    rustup component add llvm-tools-preview
-    ```
-
-- **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
 
 Building WASM requires `trunk`:
 

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/9047632/226387411-70f662de-0681-47ff-b
 - Physics via [`bevy_rapier`](https://crates.io/crates/bevy_rapier)
 - Audio via [`bevy_kira_audio`](https://crates.io/crates/bevy_kira_audio)
 - Pathfinding via [`oxidized_navigation`](https://crates.io/crates/oxidized_navigation)
-- [`bevy_editor_pls`](https://crates.io/crates/bevy_editor_pls) in the `dev` feature, bound to 'G'
+- [`bevy_editor_pls`](https://crates.io/crates/bevy_editor_pls) bound to 'G'
 - Custom editor for the game state found in the windows selection for `bevy_editor_pls`.
 - Saving / loading levels
 - Saving / loading the game state
@@ -18,7 +18,7 @@ https://user-images.githubusercontent.com/9047632/226387411-70f662de-0681-47ff-b
 - A custom dialog system
 - Shaders
 - GLTF imports, including auto-detection of colliders
-- Dynamic builds in the `native-dev` feature
+- Dynamic builds when developing
 - Grass blades using [`warbler_grass`](https://crates.io/crates/warbler_grass)
 - Smooth cameras via [`bevy_dolly`](https://github.com/BlackPhlox/bevy_dolly)
 - A skydome that follows the camera
@@ -42,7 +42,7 @@ cargo run
 ```
 Wasm:
 ```bash
-trunk serve --no-default-features --features wasm_dev
+trunk serve
 ```
 
 Building WASM requires `trunk`:

--- a/src/bevy_config.rs
+++ b/src/bevy_config.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use bevy::prelude::*;
 use bevy::window::PresentMode;
 use bevy::window::PrimaryWindow;
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 use bevy::window::WindowMode;
 use bevy::winit::WinitWindows;
 use bevy_mod_sysfail::macros::*;
@@ -18,14 +18,14 @@ pub(crate) fn bevy_config_plugin(app: &mut App) {
             canvas: Some("#bevy".to_owned()),
             present_mode: PresentMode::AutoVsync,
             // This breaks WASM for some reason
-            #[cfg(not(feature = "wasm"))]
+            #[cfg(not(target_arch = "wasm32"))]
             mode: WindowMode::BorderlessFullscreen,
             fit_canvas_to_parent: true,
             ..default()
         }),
         ..default()
     });
-    #[cfg(feature = "native-dev")]
+    #[cfg(not(target_arch = "wasm32"))]
     let default_plugins = default_plugins.set(AssetPlugin {
         watch_for_changes: true,
         ..default()

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -12,7 +12,7 @@ pub(crate) mod dev_editor;
 /// Don't include this in a release build.
 pub(crate) fn dev_plugin(app: &mut App) {
     {
-        app.add_plugin(EditorPlugin)
+        app.add_plugin(EditorPlugin::new())
             .insert_resource(default_editor_controls())
             .add_plugin(FrameTimeDiagnosticsPlugin)
             .add_plugin(DebugLinesPlugin::default())

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -32,7 +32,7 @@ fn default_editor_controls() -> bevy_editor_pls::controls::EditorControls {
     editor_controls.insert(
         Action::PlayPauseEditor,
         Binding {
-            input: UserInput::Single(Button::Keyboard(KeyCode::Q)),
+            input: UserInput::Single(Button::Keyboard(KeyCode::G)),
             conditions: vec![BindingCondition::ListeningForText(false)],
         },
     );

--- a/src/dev/dev_editor.rs
+++ b/src/dev/dev_editor.rs
@@ -7,7 +7,10 @@ use anyhow::{Context, Result};
 use bevy::prelude::*;
 use bevy::window::CursorGrabMode;
 use bevy_editor_pls::editor_window::EditorWindow;
-use bevy_editor_pls::{AddEditorWindow, Editor, EditorEvent};
+use bevy_editor_pls::{
+    editor::{Editor, EditorEvent},
+    AddEditorWindow,
+};
 use bevy_egui::egui;
 use bevy_egui::egui::ScrollArea;
 use bevy_mod_sysfail::macros::*;

--- a/src/file_system_interaction/asset_loading.rs
+++ b/src/file_system_interaction/asset_loading.rs
@@ -60,9 +60,12 @@ pub(crate) struct AnimationAssets {
 
 #[derive(AssetCollection, Resource, Clone)]
 pub(crate) struct LevelAssets {
-    #[cfg_attr(feature = "native", asset(path = "levels", collection(typed, mapped)))]
     #[cfg_attr(
-        feature = "wasm",
+        not(target_arch = "wasm32"),
+        asset(path = "levels", collection(typed, mapped))
+    )]
+    #[cfg_attr(
+        target_arch = "wasm32",
         asset(paths("levels/old_town.lvl.ron"), collection(typed, mapped))
     )]
     pub(crate) levels: HashMap<String, Handle<SerializedLevel>>,
@@ -70,9 +73,12 @@ pub(crate) struct LevelAssets {
 
 #[derive(AssetCollection, Resource, Clone)]
 pub(crate) struct DialogAssets {
-    #[cfg_attr(feature = "native", asset(path = "dialogs", collection(typed, mapped)))]
     #[cfg_attr(
-        feature = "wasm",
+        not(target_arch = "wasm32"),
+        asset(path = "dialogs", collection(typed, mapped))
+    )]
+    #[cfg_attr(
+        target_arch = "wasm32",
         asset(paths("dialogs/follower.dlg.ron"), collection(typed, mapped))
     )]
     pub(crate) dialogs: HashMap<String, Handle<Dialog>>,

--- a/src/ingame_menu.rs
+++ b/src/ingame_menu.rs
@@ -44,7 +44,7 @@ fn handle_pause(
 
                             if ui.button("Quit Game").clicked() {
                                 app_exit_events.send(AppExit);
-                                #[cfg(feature = "wasm")]
+                                #[cfg(target_arch = "wasm32")]
                                 wasm::close_tab()
                             }
                         });
@@ -58,7 +58,7 @@ fn handle_pause(
     }
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 mod wasm {
     use wasm_bindgen::prelude::*;
 

--- a/src/level_instantiation/map.rs
+++ b/src/level_instantiation/map.rs
@@ -18,7 +18,7 @@ pub(crate) fn map_plugin(app: &mut App) {
             .in_set(OnUpdate(GameState::Playing)),
     );
 
-    #[cfg(feature = "wasm")]
+    #[cfg(target_arch = "wasm32")]
     app.add_system(show_wasm_loader.in_set(OnUpdate(GameState::Playing)));
 }
 
@@ -49,15 +49,15 @@ fn show_loading_screen(mut egui_contexts: EguiContexts) {
             ui.heading("Loading");
             ui.label("Spawning level...");
             ui.add_space(10.0);
-            #[cfg(feature = "wasm")]
+            #[cfg(target_arch = "wasm32")]
             ui.add_space(40.0); // Spinner from CSS (build/web/styles.css) goes here.
-            #[cfg(feature = "wasm")]
+            #[cfg(target_arch = "wasm32")]
             ui.label("This may take a while. Don't worry, your browser did not crash!");
         });
     });
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 fn show_wasm_loader(player_query: Query<&Player>, mut egui_contexts: EguiContexts) {
     let id = egui::Id::new("loading-screen-shown");
     egui_contexts.ctx_mut().memory_mut(|memory| {
@@ -76,7 +76,7 @@ fn show_wasm_loader(player_query: Query<&Player>, mut egui_contexts: EguiContext
     });
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(target_arch = "wasm32")]
 mod loader {
     use wasm_bindgen::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) mod ingame_menu;
 pub(crate) mod level_instantiation;
 pub(crate) mod menu;
 pub(crate) mod movement;
-#[cfg(feature = "native")]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod particles;
 pub(crate) mod player_control;
 pub(crate) mod shader;
@@ -38,7 +38,7 @@ use crate::ingame_menu::ingame_menu_plugin;
 use crate::level_instantiation::level_instantiation_plugin;
 use crate::menu::menu_plugin;
 use crate::movement::movement_plugin;
-#[cfg(feature = "native")]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::particles::particle_plugin;
 use crate::player_control::player_control_plugin;
 use crate::shader::shader_plugin;
@@ -77,15 +77,6 @@ pub struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(not(feature = "core"))]
-        compile_error!("You need to compile with the core feature.");
-        #[cfg(all(feature = "wasm", feature = "native"))]
-        compile_error!(
-            "You can only compile with the wasm or native features, not both at the same time."
-        );
-        #[cfg(all(feature = "native-dev", not(feature = "native")))]
-        compile_error!("You can only compile with the native-dev feature if you compile with the native feature.");
-
         app.add_state::<GameState>()
             .fn_plugin(bevy_config_plugin)
             .fn_plugin(menu_plugin)
@@ -98,7 +89,7 @@ impl Plugin for GamePlugin {
             .fn_plugin(ingame_menu_plugin);
         #[cfg(feature = "dev")]
         app.fn_plugin(dev_plugin);
-        #[cfg(feature = "native")]
+        #[cfg(not(target_arch = "wasm32"))]
         app.fn_plugin(particle_plugin);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // disable console on windows for release builds
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(not(feature = "dev"), windows_subsystem = "windows")]
 
 use bevy::prelude::*;
 use foxtrot::GamePlugin;

--- a/src/movement/navigation.rs
+++ b/src/movement/navigation.rs
@@ -58,7 +58,7 @@ fn query_mesh(
     nav_mesh_settings: Res<NavMeshSettings>,
     nav_mesh: Res<NavMesh>,
     #[cfg(feature = "dev")] mut lines: ResMut<DebugLines>,
-    #[cfg(feature = "dev")] editor_state: Res<bevy_editor_pls::Editor>,
+    #[cfg(feature = "dev")] editor_state: Res<bevy_editor_pls::editor::Editor>,
 ) -> Result<()> {
     #[cfg(feature = "tracing")]
     let _span = info_span!("query_mesh").entered();


### PR DESCRIPTION
Thanks to Thierry Berger for providing the feedback that this PR is based on!

- Moves editor key to "G"
- Improves compile times a bit
- Removes all external deps by default (lld, zld, clang)
- Removes default lld linker -> no more linker errors requiring rebuilds
- Removes all cargo features and instead automatically sets up the right dependencies, except for the `dev `feature which is always active by default