### PR TITLE
build(toolchain): pin Rust nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-06-15"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Pin Rust nightly version to allow successful build.

Closes #274