### PR TITLE
De-duplicate syn dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.CARGO_TOOLCHAIN }}
@@ -29,7 +29,7 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.CARGO_TOOLCHAIN }}
@@ -45,7 +45,7 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.CARGO_TOOLCHAIN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Remove build script
         run: |
           rm build.rs
@@ -81,7 +81,7 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -116,7 +116,7 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,7 +1634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
  "serde",
 ]
 
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 dependencies = [
  "jobserver",
  "libc",
@@ -2067,14 +2067,13 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 [[package]]
 name = "derive_more"
 version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+source = "git+https://github.com/bash/derive_more.git?branch=backport-syn-update#da1202282c664fdfd9310e3b2a5ded8cff63bb99"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2124,10 +2123,6 @@ name = "duplicate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
-]
 
 [[package]]
 name = "ecolor"
@@ -2162,9 +2157,8 @@ dependencies = [
 
 [[package]]
 name = "egui_dock"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a062ac200c9f3ddf120ffcc5582f9fbd5d8fbd046d2eed215ed5426f56513d0"
+version = "0.11.3"
+source = "git+https://github.com/bash/egui_dock.git?branch=backport-syn-update#212e94d65ee2265dd6e097a5592ebf5d1736660e"
 dependencies = [
  "duplicate",
  "egui",
@@ -2764,12 +2758,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2817,6 +2805,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locid"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2851,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
 
 [[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
 name = "icu_plurals"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2893,27 @@ name = "icu_plurals_data"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3e8f775b215d45838814a090a2227247a7431d74e9156407d9c37f6ef0f208"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
@@ -2900,12 +2945,14 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -3215,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3408,7 +3455,7 @@ dependencies = [
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rustc-hash",
  "thiserror",
  "tracing",
@@ -3435,12 +3482,11 @@ dependencies = [
 [[package]]
 name = "nalgebra-macros"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
+source = "git+https://github.com/bash/nalgebra.git?branch=backport-syn-update#beacb25173aeaa868992b55804e9718e7b5fa1da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4098,30 +4144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4315,14 +4337,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4336,13 +4358,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4353,9 +4375,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4649,11 +4671,11 @@ checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4874,14 +4896,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.14",
 ]
 
 [[package]]
@@ -4906,15 +4928,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.9",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -5080,12 +5102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5108,9 +5124,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -5120,14 +5136,26 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -5332,7 +5360,7 @@ dependencies = [
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle 0.6.2",
  "smallvec",
@@ -5360,7 +5388,7 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "raw-window-handle 0.6.2",
  "rustc-hash",
@@ -5402,7 +5430,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
  "raw-window-handle 0.6.2",
@@ -5429,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.21"
+version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8dc749a1b03f3c255a3064a4f5c0ee5ed09b7c6bc6d4525d31f779cd74d7fc"
+checksum = "8a040b111774ab63a19ef46bbc149398ab372b4ccdcfd719e9814dbd7dfd76c8"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -5548,9 +5576,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -5811,9 +5839,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -5827,6 +5855,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
@@ -5887,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "xkeysym"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,8 +1465,7 @@ dependencies = [
 [[package]]
 name = "bevy_yarnspinner"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31a28cad3a545ebcac1347e107e06c6bc81228841fe1b60d94db82c6e6d31ad"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1481,8 +1480,7 @@ dependencies = [
 [[package]]
 name = "bevy_yarnspinner_example_dialogue_view"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef048b716e03413534048f307310d39783659755bceb4b7f9f8360c1c67581"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "bevy",
  "bevy_yarnspinner",
@@ -2755,12 +2753,6 @@ dependencies = [
  "widestring",
  "winapi",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -4451,12 +4443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "ruzstd"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4662,25 +4648,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strum"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "svg_fmt"
@@ -5934,8 +5901,7 @@ checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 [[package]]
 name = "yarnspinner"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39473a37f93e84dadb0be4c3df88d7a614e90df98bb852b847c7624e6794e38"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "log",
  "yarnspinner_compiler",
@@ -5946,8 +5912,7 @@ dependencies = [
 [[package]]
 name = "yarnspinner_compiler"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9f57c0f8d0754b98c83dbd25b69c0015755486428d9726aefe84324a5d235a"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "annotate-snippets",
  "antlr-rust",
@@ -5957,34 +5922,24 @@ dependencies = [
  "rand",
  "regex",
  "serde",
- "strum",
- "strum_macros",
- "thiserror",
  "yarnspinner_core",
 ]
 
 [[package]]
 name = "yarnspinner_core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe49910e13e0254e50201a80fb450e5d6382feee3b09c44bb3914d32e356600"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "bevy",
- "bytes",
- "paste",
  "prost",
  "serde",
- "strum",
- "strum_macros",
- "thiserror",
  "yarnspinner_macros",
 ]
 
 [[package]]
 name = "yarnspinner_macros"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ae8c98bd97e554fe9a4c593a1438492611d93a0b92075467984167cd896b30"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5994,8 +5949,7 @@ dependencies = [
 [[package]]
 name = "yarnspinner_runtime"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc42ff1081804df3e43f238076294223d77266dbe99adaf835b5907a3b1b6a4"
+source = "git+https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git?rev=c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30#c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30"
 dependencies = [
  "bevy",
  "fixed_decimal",
@@ -6005,7 +5959,6 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "thiserror",
  "unicode-normalization",
  "unicode-segmentation",
  "yarnspinner_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,7 @@ strip = true
 nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" } # https://github.com/dimforge/nalgebra/pull/1342
 derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" }
 egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" }
+
+# These patches mainly remove strum and are included in bevy_yarnspinner 0.3.0-rc
+bevy_yarnspinner = { git = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git", rev = "c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30" }
+bevy_yarnspinner_example_dialogue_view = { git = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git", rev = "c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ strip = true
 # * com-macros and com_macros_support (unlikely to receive updates)
 # * windows-implement and windows-interface (updated to syn 2 in Bevy 0.14.0-rc.2)
 nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" } # https://github.com/dimforge/nalgebra/pull/1342
-derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" }
+derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" } # https://github.com/JelteF/derive_more/issues/368
 egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" }
 
 # These patches mainly remove strum and are included in bevy_yarnspinner 0.3.0-rc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ codegen-units = 1
 strip = true
 
 [patch.crates-io]
-nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" }
+# Patches that replace syn 1 with syn 2
+# Note that windows still uses syn 1 through
+# * com-macros and com_macros_support (unlikely to receive updates)
+# * windows-implement and windows-interface (updated to syn 2 in Bevy 0.14.0-rc.2)
+nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" } # https://github.com/dimforge/nalgebra/pull/1342
 derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" }
 egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ leafwing-input-manager = { version = "0.13", features = ["egui"] }
 bevy_dolly = "0.0.3"
 bevy_mod_sysfail = "7"
 bevy_editor_pls = { version = "0.8.1", optional = true }
-bevy_hanabi = "0.10" # Not on 0.11 yet because of Hanabi bugs ("Failed to find update pipeline")
+bevy_hanabi = { version = "0.10", default-features = false, features = ["3d"] } # Not on 0.11 yet because of Hanabi bugs ("Failed to find update pipeline")
 bevy_yarnspinner = "0.2"
 bevy_yarnspinner_example_dialogue_view = "0.2.1"
 bevy-tnua-xpbd3d = "0.4"
@@ -77,3 +77,8 @@ opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
+
+[patch.crates-io]
+nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" }
+derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" }
+egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ strip = true
 # * windows-implement and windows-interface (updated to syn 2 in Bevy 0.14.0-rc.2)
 nalgebra-macros = { git = "https://github.com/bash/nalgebra.git", branch = "backport-syn-update" } # https://github.com/dimforge/nalgebra/pull/1342
 derive_more = { git = "https://github.com/bash/derive_more.git", branch = "backport-syn-update" } # https://github.com/JelteF/derive_more/issues/368
-egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" }
+egui_dock = { git = "https://github.com/bash/egui_dock.git", branch = "backport-syn-update" } # This change is not PR-worthy. Instead, I made a PR to the actually affected dependency `duplicate`: https://github.com/Emoun/duplicate/pull/62
 
 # These patches mainly remove strum and are included in bevy_yarnspinner 0.3.0-rc
 bevy_yarnspinner = { git = "https://github.com/YarnSpinnerTool/YarnSpinner-Rust.git", rev = "c6ab0c9e8c3a5a98f741aaae6adef1cfc272db30" }


### PR DESCRIPTION
Unfortunately we still have syn 1 on windows :/

`cargo tree -i syn@1.0.109 --target all`