### PR TITLE
Refactor system sets

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -1,40 +1,145 @@
-# Add the contents of this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
-
-# NOTE: For maximum performance, build using a nightly compiler
-# If you are using rust stable, remove the "-Zshare-generics=y" below.
+# Copy this file to `config.toml` to speed up your builds.
+#
+# # Faster linker
+#
+# One of the slowest aspects of compiling large Rust programs is the linking time. This file configures an
+# alternate linker that may improve build times. When choosing a new linker, you have two options:
+#
+# ## LLD
+#
+# LLD is a linker from the LLVM project that supports Linux, Windows, MacOS, and WASM. It has the greatest
+# platform support and the easiest installation process. It is enabled by default in this file for Linux
+# and Windows. On MacOS, the default linker yields higher performance than LLD and is used instead.
+#
+# To install, please scroll to the corresponding table for your target (eg. `[target.x86_64-pc-windows-msvc]`
+# for Windows) and follow the steps under `LLD linker`.
+#
+# For more information, please see LLD's website at <https://lld.llvm.org>.
+#
+# ## Mold
+#
+# Mold is a newer linker written by one of the authors of LLD. It boasts even greater performance, specifically
+# through its high parallelism, though it only supports Linux.
+#
+# Mold is  disabled by default in this file. If you wish to enable it, follow the installation instructions for
+# your corresponding target, disable LLD by commenting out its `-Clink-arg=...` line, and enable Mold by
+# *uncommenting* its `-Clink-arg=...` line.
+#
+# There is a fork of Mold named Sold that supports MacOS, but it is unmaintained and is about the same speed as
+# the default ld64 linker. For this reason, it is not included in this file.
+#
+# For more information, please see Mold's repository at <https://github.com/rui314/mold>.
+#
+# # Nightly configuration
+#
+# Be warned that the following features require nightly Rust, which is expiremental and may contain bugs. If you
+# are having issues, skip this section and use stable Rust instead.
+#
+# There are a few unstable features that can improve performance. To use them, first install nightly Rust
+# through Rustup:
+#
+# ```
+# rustup toolchain install nightly
+# ```
+#
+# Finally, uncomment the lines under the `Nightly` heading for your corresponding target table (eg.
+# `[target.x86_64-unknown-linux-gnu]` for Linux) to enable the following features:
+#
+# ## `share-generics`
+#
+# Usually rustc builds each crate separately, then combines them all together at the end. `share-generics` forces
+# crates to share monomorphized generic code, so they do not duplicate work.
+#
+# In other words, instead of crate 1 generating `Foo<String>` and crate 2 generating `Foo<String>` separately,
+# only one crate generates `Foo<String>` and the other adds on to the pre-exiting work.
+#
+# Note that you may have some issues with this flag on Windows. If compiling fails due to the 65k symbol limit,
+# you may have to disable this setting. For more information and possible solutions to this error, see
+# <https://github.com/bevyengine/bevy/issues/1110>.
+#
+# ## `threads`
+#
+# This option enables rustc's parallel frontend, which improves performance when parsing, type checking, borrow
+# checking, and more. We currently set `threads=0`, which defaults to the amount of cores in your CPU.
+#
+# For more information, see the blog post at <https://blog.rust-lang.org/2023/11/09/parallel-rustc.html>.
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = [
-    "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
-    "-Zshare-generics=y", # (Nightly) Make the current crate share its generic instantiations
-    "-Zthreads=0", # (Nightly) Use improved multithreading with the recommended amount of threads.
+    # LLD linker
+    #
+    # You may need to install it:
+    #
+    # - Ubuntu: `sudo apt-get install lld clang`
+    # - Fedora: `sudo dnf install lld clang`
+    # - Arch: `sudo pacman -S lld clang`
+    "-Clink-arg=-fuse-ld=lld",
+    # Mold linker
+    #
+    # You may need to install it:
+    #
+    # - Ubuntu: `sudo apt-get install mold clang`
+    # - Fedora: `sudo dnf install mold clang`
+    # - Arch: `sudo pacman -S mold clang`
+    # "-Clink-arg=-fuse-ld=/usr/bin/mold",
+
+    # Nightly
+    # "-Zshare-generics=y",
+    # "-Zthreads=0",
 ]
 
-# NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
-# `brew install llvm`
 [target.x86_64-apple-darwin]
 rustflags = [
-    "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
-    "-Zshare-generics=y", # (Nightly) Make the current crate share its generic instantiations
-    "-Zthreads=0", # (Nightly) Use improved multithreading with the recommended amount of threads.
+    # LLD linker
+    #
+    # The default ld64 linker is faster, you should continue using it instead.
+    #
+    # You may need to install it:
+    #
+    # Brew: `brew install llvm`
+    # Manually: <https://lld.llvm.org/MachO/index.html>
+    # "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld",
+
+    # Nightly
+    # "-Zshare-generics=y",
+    # "-Zthreads=0",
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
-    "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
-    "-Zshare-generics=y", # (Nightly) Make the current crate share its generic instantiations
-    "-Zthreads=0", # (Nightly) Use improved multithreading with the recommended amount of threads.
+    # LLD linker
+    #
+    # The default ld64 linker is faster, you should continue using it instead.
+    #
+    # You may need to install it:
+    #
+    # Brew: `brew install llvm`
+    # Manually: <https://lld.llvm.org/MachO/index.html>
+    # "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld",
+
+    # Nightly
+    # "-Zshare-generics=y",
+    # "-Zthreads=0",
 ]
 
 [target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe" # Use LLD Linker
+# LLD linker
+#
+# You may need to install it:
+#
+# ```
+# cargo install -f cargo-binutils
+# rustup component add llvm-tools
+# ```
+linker = "rust-lld.exe"
 rustflags = [
-    "-Zshare-generics=n",
-    "-Zthreads=0", # (Nightly) Use improved multithreading with the recommended amount of threads.
+    # Nightly
+    # "-Zshare-generics=y",
+    # "-Zthreads=0",
 ]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.
-#[profile.dev]
-#debug = 1
+# [profile.dev]
+# debug = 1

--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -1,4 +1,4 @@
-# Rename this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
+# Add the contents of this file to `config.toml` to enable "fast build" configuration. Please read the notes below.
 
 # NOTE: For maximum performance, build using a nightly compiler
 # If you are using rust stable, remove the "-Zshare-generics=y" below.
@@ -30,7 +30,7 @@ rustflags = [
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe" # Use LLD Linker
 rustflags = [
-    "-Zshare-generics=n", # (Nightly)
+    "-Zshare-generics=n",
     "-Zthreads=0", # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,30 +1064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_mod_sysfail"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a58f0be698c10aab373413556a89e193a783a7241ed3ed5971330a284a7c3b"
-dependencies = [
- "anyhow",
- "bevy",
- "bevy_ecs",
- "bevy_mod_sysfail_macros",
- "bevy_utils",
-]
-
-[[package]]
-name = "bevy_mod_sysfail_macros"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595deba61fcc75116469575cec8abfa9ea2b74b905501daa6e34f0fa588f34d8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "bevy_pbr"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,7 +2416,6 @@ dependencies = [
  "bevy_gltf_blueprints",
  "bevy_hanabi",
  "bevy_kira_audio",
- "bevy_mod_sysfail",
  "bevy_registry_export",
  "bevy_xpbd_3d",
  "bevy_yarnspinner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ oxidized_navigation = { version = "0.10", features = ["xpbd"] }
 iyes_progress = "0.11"
 leafwing-input-manager = { version = "0.13", features = ["egui"] }
 bevy_dolly = "0.0.3"
-bevy_mod_sysfail = "7"
 bevy_editor_pls = { version = "0.8.1", optional = true }
 bevy_hanabi = { version = "0.11", default-features = false, features = ["3d"] }
 bevy_yarnspinner = "0.2"

--- a/readme.md
+++ b/readme.md
@@ -6,22 +6,21 @@ https://user-images.githubusercontent.com/9047632/226387411-70f662de-0681-47ff-b
 
 ## What does this template give you?
 
-- A 3D character controller via [`bevy-tnua`](https://crates.io/crates/bevy-tnua)
+- Integration with Blender as an editor via
+  the [`Blender_bevy_components_workflow`](https://github.com/kaosat-dev/Blender_bevy_components_workflow) set of tools
 - Physics via [`bevy_xpbd`](https://crates.io/crates/bevy_xpbd_3d)
+    - A 3D character controller via [`bevy-tnua`](https://crates.io/crates/bevy-tnua)
 - Audio via [`bevy_kira_audio`](https://crates.io/crates/bevy_kira_audio)
 - Pathfinding via [`oxidized_navigation`](https://crates.io/crates/oxidized_navigation)
 - [`bevy_editor_pls`](https://crates.io/crates/bevy_editor_pls) bound to 'Q'
-- Custom editor found in the windows selection for `bevy_editor_pls`.
+    - Custom editor found in the windows selection for `bevy_editor_pls`.
 - Animations
 - Dialogs via [`Yarn Spinner for Rust`](https://crates.io/crates/bevy_yarnspinner)
 - Shaders, using the code from [DGriffin's tutorial](https://www.youtube.com/watch?v=O6A_nVmpvhc)
-- GLTF imports, including auto-insertion of markers via the GLTF extras field
 - Smooth cameras via [`bevy_dolly`](https://crates.io/crates/bevy_dolly)
 - Particle effects via [`bevy_hanabi`](https://crates.io/crates/bevy_hanabi)
 - Procedural skies via [`bevy_atmosphere`](https://crates.io/crates/bevy_atmosphere)
 - Grass via [`warbler_grass`](https://crates.io/crates/warbler_grass)
-- Integration with Blender as an editor via
-  the [`Blender_bevy_components_workflow`](https://github.com/kaosat-dev/Blender_bevy_components_workflow) set of tools
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,6 @@ https://user-images.githubusercontent.com/9047632/226387411-70f662de-0681-47ff-b
 - Shaders, using the code from [DGriffin's tutorial](https://www.youtube.com/watch?v=O6A_nVmpvhc)
 - GLTF imports, including auto-insertion of markers via the GLTF extras field
 - Smooth cameras via [`bevy_dolly`](https://crates.io/crates/bevy_dolly)
-- Simple error handling via [`bevy_mod_sysfail`](https://crates.io/crates/bevy_mod_sysfail)
 - Particle effects via [`bevy_hanabi`](https://crates.io/crates/bevy_hanabi)
 - Procedural skies via [`bevy_atmosphere`](https://crates.io/crates/bevy_atmosphere)
 - Grass via [`warbler_grass`](https://crates.io/crates/warbler_grass)

--- a/src/dev/dev_editor.rs
+++ b/src/dev/dev_editor.rs
@@ -1,4 +1,4 @@
-use crate::{player_control::camera::ForceCursorGrabMode, GameState};
+use crate::player_control::camera::ForceCursorGrabMode;
 use anyhow::Context;
 use bevy::{prelude::*, window::CursorGrabMode};
 use bevy_editor_pls::{
@@ -14,10 +14,7 @@ use serde::{Deserialize, Serialize};
 pub(super) fn plugin(app: &mut App) {
     app.init_resource::<DevEditorState>()
         .add_editor_window::<DevEditorWindow>()
-        .add_systems(
-            Update,
-            (handle_debug_render, set_cursor_grab_mode).run_if(in_state(GameState::Playing)),
-        );
+        .add_systems(Update, (handle_debug_render, set_cursor_grab_mode));
 }
 
 pub(crate) struct DevEditorWindow;

--- a/src/dev/dev_editor.rs
+++ b/src/dev/dev_editor.rs
@@ -1,4 +1,5 @@
 use crate::player_control::camera::ForceCursorGrabMode;
+use crate::util::error;
 use anyhow::Context;
 use bevy::{prelude::*, window::CursorGrabMode};
 use bevy_editor_pls::{
@@ -7,14 +8,16 @@ use bevy_editor_pls::{
     AddEditorWindow,
 };
 use bevy_egui::egui;
-use bevy_mod_sysfail::prelude::*;
 use bevy_xpbd_3d::prelude::PhysicsGizmos;
 use serde::{Deserialize, Serialize};
 
 pub(super) fn plugin(app: &mut App) {
     app.init_resource::<DevEditorState>()
         .add_editor_window::<DevEditorWindow>()
-        .add_systems(Update, (handle_debug_render, set_cursor_grab_mode));
+        .add_systems(
+            Update,
+            (handle_debug_render.pipe(error), set_cursor_grab_mode),
+        );
 }
 
 pub(crate) struct DevEditorWindow;
@@ -48,12 +51,11 @@ pub(crate) struct DevEditorState {
     pub(crate) navmesh_render_enabled: bool,
 }
 
-#[sysfail(Log<anyhow::Error, Error>)]
 fn handle_debug_render(
     state: Res<Editor>,
     mut last_enabled: Local<bool>,
     mut config_store: ResMut<GizmoConfigStore>,
-) {
+) -> anyhow::Result<()> {
     let current_enabled = state
         .window_state::<DevEditorWindow>()
         .context("Failed to read dev window state")?
@@ -64,6 +66,7 @@ fn handle_debug_render(
     *last_enabled = current_enabled;
     let config = config_store.config_mut::<PhysicsGizmos>().0;
     config.enabled = current_enabled;
+    Ok(())
 }
 
 fn set_cursor_grab_mode(

--- a/src/file_system_interaction/asset_loading.rs
+++ b/src/file_system_interaction/asset_loading.rs
@@ -4,7 +4,6 @@ use bevy_asset_loader::prelude::*;
 use bevy_common_assets::toml::TomlAssetPlugin;
 use bevy_egui::{egui, egui::ProgressBar, EguiContexts};
 use bevy_kira_audio::AudioSource;
-use bevy_mod_sysfail::prelude::*;
 use iyes_progress::{ProgressCounter, ProgressPlugin};
 
 /// Loads resources and assets for the game.
@@ -95,7 +94,6 @@ fn show_progress(
     }
 }
 
-#[sysfail(Log<anyhow::Error, Error>)]
 fn update_config(
     mut commands: Commands,
     config: Res<Assets<GameConfig>>,

--- a/src/level_instantiation/on_spawn/collider.rs
+++ b/src/level_instantiation/on_spawn/collider.rs
@@ -1,4 +1,4 @@
-use crate::{movement::physics::CollisionLayer, GameState, GameSystemSet};
+use crate::{movement::physics::CollisionLayer, GameSystemSet};
 use anyhow::Context;
 use bevy::prelude::*;
 use bevy_mod_sysfail::prelude::*;
@@ -12,12 +12,8 @@ use std::iter;
 struct Collider;
 
 pub(super) fn plugin(app: &mut App) {
-    app.register_type::<Collider>().add_systems(
-        Update,
-        spawn
-            .in_set(GameSystemSet::ColliderSpawn)
-            .run_if(in_state(GameState::Playing)),
-    );
+    app.register_type::<Collider>()
+        .add_systems(Update, spawn.in_set(GameSystemSet::ColliderSpawn));
 }
 
 #[sysfail(Log<anyhow::Error, Error>)]

--- a/src/level_instantiation/on_spawn/collider.rs
+++ b/src/level_instantiation/on_spawn/collider.rs
@@ -1,4 +1,4 @@
-use crate::{movement::physics::CollisionLayer, GameState};
+use crate::{movement::physics::CollisionLayer, GameState, GameSystemSet};
 use anyhow::Context;
 use bevy::prelude::*;
 use bevy_mod_sysfail::prelude::*;
@@ -12,8 +12,12 @@ use std::iter;
 struct Collider;
 
 pub(super) fn plugin(app: &mut App) {
-    app.register_type::<Collider>()
-        .add_systems(Update, spawn.run_if(in_state(GameState::Playing)));
+    app.register_type::<Collider>().add_systems(
+        Update,
+        spawn
+            .in_set(GameSystemSet::ColliderSpawn)
+            .run_if(in_state(GameState::Playing)),
+    );
 }
 
 #[sysfail(Log<anyhow::Error, Error>)]

--- a/src/level_instantiation/on_spawn/hidden.rs
+++ b/src/level_instantiation/on_spawn/hidden.rs
@@ -1,6 +1,5 @@
 use crate::GameState;
 use bevy::prelude::*;
-use bevy_xpbd_3d::PhysicsSet;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Component, Reflect, Serialize, Deserialize, Default)]
@@ -8,12 +7,8 @@ use serde::{Deserialize, Serialize};
 struct Hidden;
 
 pub(super) fn plugin(app: &mut App) {
-    app.register_type::<Hidden>().add_systems(
-        Update,
-        spawn
-            .after(PhysicsSet::Sync)
-            .run_if(in_state(GameState::Playing)),
-    );
+    app.register_type::<Hidden>()
+        .add_systems(Update, spawn.run_if(in_state(GameState::Playing)));
 }
 
 fn spawn(hidden: Query<Entity, Added<Hidden>>, mut commands: Commands) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,11 @@ pub(crate) mod movement;
 pub(crate) mod particles;
 mod player_control;
 mod shader;
+mod system_set;
 pub(crate) mod util;
 mod world_interaction;
+
+pub(crate) use system_set::GameSystemSet;
 
 #[derive(States, Default, Clone, Eq, PartialEq, Debug, Hash)]
 enum GameState {
@@ -55,6 +58,7 @@ pub struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.init_state::<GameState>().add_plugins((
+            system_set::plugin,
             bevy_config::plugin,
             menu::plugin,
             movement::plugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ enum GameState {
 /// Main entrypoint for Foxtrot.
 ///
 /// The top-level plugins are:
+/// - [`system_set::plugin`]: Sets up the system set used to order systems across Foxtrot.
 /// - [`bevy_config::plugin`]: Sets up the bevy configuration.
 /// - [`menu::plugin`]: Handles the menu.
 /// - [`movement::plugin`]: Handles the movement of entities.

--- a/src/movement/character_controller.rs
+++ b/src/movement/character_controller.rs
@@ -1,9 +1,9 @@
+use crate::system_set::GameSystemSet;
 use crate::GameState;
 pub(crate) use animation::AnimationState;
 use bevy::prelude::*;
 use bevy_tnua::prelude::*;
 use bevy_tnua_xpbd3d::*;
-use bevy_xpbd_3d::PhysicsSet;
 pub(crate) use components::*;
 
 mod animation;
@@ -19,14 +19,10 @@ pub(super) fn plugin(app: &mut App) {
             Update,
             (apply_jumping, apply_walking)
                 .chain()
-                .in_set(GeneralMovementSystemSet)
-                .before(PhysicsSet::Prepare)
+                .in_set(GameSystemSet::GeneralMovement)
                 .run_if(in_state(GameState::Playing)),
         );
 }
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub(crate) struct GeneralMovementSystemSet;
 
 fn apply_walking(
     mut character_query: Query<(

--- a/src/movement/character_controller.rs
+++ b/src/movement/character_controller.rs
@@ -1,5 +1,4 @@
 use crate::system_set::GameSystemSet;
-use crate::GameState;
 pub(crate) use animation::AnimationState;
 use bevy::prelude::*;
 use bevy_tnua::prelude::*;
@@ -19,8 +18,7 @@ pub(super) fn plugin(app: &mut App) {
             Update,
             (apply_jumping, apply_walking)
                 .chain()
-                .in_set(GameSystemSet::GeneralMovement)
-                .run_if(in_state(GameState::Playing)),
+                .in_set(GameSystemSet::GeneralMovement),
         );
 }
 

--- a/src/movement/character_controller/animation.rs
+++ b/src/movement/character_controller/animation.rs
@@ -1,3 +1,4 @@
+use crate::system_set::GameSystemSet;
 use bevy::{animation::AnimationPlayer, prelude::*};
 use bevy_gltf_blueprints::{AnimationPlayerLink, Animations};
 use bevy_mod_sysfail::prelude::*;
@@ -6,7 +7,6 @@ use bevy_tnua::{
     TnuaAnimatingStateDirective,
 };
 use std::time::Duration;
-use crate::system_set::GameSystemSet;
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<CharacterAnimationNames>()

--- a/src/movement/character_controller/animation.rs
+++ b/src/movement/character_controller/animation.rs
@@ -6,10 +6,11 @@ use bevy_tnua::{
     TnuaAnimatingStateDirective,
 };
 use std::time::Duration;
+use crate::system_set::GameSystemSet;
 
 pub(super) fn plugin(app: &mut App) {
     app.register_type::<CharacterAnimationNames>()
-        .add_systems(Update, play_animations);
+        .add_systems(Update, play_animations.in_set(GameSystemSet::PlayAnimation));
 }
 
 /// Managed by [`play_animations`]

--- a/src/movement/character_controller/models.rs
+++ b/src/movement/character_controller/models.rs
@@ -1,6 +1,5 @@
 use crate::movement::character_controller::FloatHeight;
 use crate::GameState;
-use bevy::transform::TransformSystem;
 use bevy::{prelude::*, render::view::NoFrustumCulling};
 use bevy_tnua::controller::TnuaController;
 use bevy_xpbd_3d::prelude::*;
@@ -8,10 +7,7 @@ use bevy_xpbd_3d::prelude::*;
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         Update,
-        prepare_models_of_controllers
-            .after(PhysicsSet::Sync)
-            .before(TransformSystem::TransformPropagate)
-            .run_if(in_state(GameState::Playing)),
+        prepare_models_of_controllers.run_if(in_state(GameState::Playing)),
     );
 }
 

--- a/src/movement/navigation.rs
+++ b/src/movement/navigation.rs
@@ -1,15 +1,15 @@
 #[cfg(feature = "dev")]
 use crate::dev::dev_editor::DevEditorWindow;
+use crate::util::error;
 use crate::{
     level_instantiation::on_spawn::{player, Npc, Player},
     movement::character_controller::Walk,
-    util::math_trait_ext::{F32Ext, Vec3Ext},
+    util::{F32Ext, Vec3Ext},
     GameSystemSet,
 };
 #[cfg(feature = "dev")]
 use anyhow::Context;
 use bevy::prelude::*;
-use bevy_mod_sysfail::prelude::*;
 use bevy_xpbd_3d::prelude::Collider;
 #[cfg(feature = "dev")]
 use oxidized_navigation::debug_draw::{DrawNavMesh, DrawPath, OxidizedNavigationDebugDrawPlugin};
@@ -40,13 +40,15 @@ pub(super) fn plugin(app: &mut App) {
         max_edge_length: 100,
         max_tile_generation_tasks: None,
     }))
-    .add_systems(Update, query_mesh.in_set(GameSystemSet::Navigation));
+    .add_systems(
+        Update,
+        query_mesh.pipe(error).in_set(GameSystemSet::Navigation),
+    );
     #[cfg(feature = "dev")]
     app.add_plugins(OxidizedNavigationDebugDrawPlugin)
-        .add_systems(Update, draw_navmesh);
+        .add_systems(Update, draw_navmesh.pipe(error));
 }
 
-#[sysfail(Log<anyhow::Error, Error>)]
 fn query_mesh(
     #[cfg(feature = "dev")] mut commands: Commands,
     mut with_follower: Query<(&Transform, &mut Walk), (With<Npc>, Without<Player>)>,
@@ -54,7 +56,7 @@ fn query_mesh(
     nav_mesh_settings: Res<NavMeshSettings>,
     nav_mesh: Res<NavMesh>,
     #[cfg(feature = "dev")] editor_state: Res<bevy_editor_pls::editor::Editor>,
-) {
+) -> anyhow::Result<()> {
     #[cfg(feature = "tracing")]
     let _span = info_span!("query_mesh").entered();
     if let Ok(nav_mesh) = nav_mesh.get().read() {
@@ -100,17 +102,18 @@ fn query_mesh(
             }
         }
     }
+    Ok(())
 }
 
 #[cfg(feature = "dev")]
-#[sysfail(Log<anyhow::Error, Error>)]
 fn draw_navmesh(
     editor: Res<bevy_editor_pls::editor::Editor>,
     mut draw_nav_mesh: ResMut<DrawNavMesh>,
-) {
+) -> anyhow::Result<()> {
     let nav_render_enabled = editor
         .window_state::<DevEditorWindow>()
         .context("Failed to read dev window state")?
         .navmesh_render_enabled;
     draw_nav_mesh.0 = nav_render_enabled;
+    Ok(())
 }

--- a/src/movement/navigation.rs
+++ b/src/movement/navigation.rs
@@ -2,9 +2,9 @@
 use crate::dev::dev_editor::DevEditorWindow;
 use crate::{
     level_instantiation::on_spawn::{player, Npc, Player},
-    movement::character_controller::{GeneralMovementSystemSet, Walk},
+    movement::character_controller::Walk,
     util::math_trait_ext::{F32Ext, Vec3Ext},
-    GameState,
+    GameState, GameSystemSet,
 };
 #[cfg(feature = "dev")]
 use anyhow::Context;
@@ -43,7 +43,7 @@ pub(super) fn plugin(app: &mut App) {
     .add_systems(
         Update,
         query_mesh
-            .before(GeneralMovementSystemSet)
+            .in_set(GameSystemSet::Navigation)
             .run_if(in_state(GameState::Playing)),
     );
     #[cfg(feature = "dev")]

--- a/src/movement/navigation.rs
+++ b/src/movement/navigation.rs
@@ -4,7 +4,7 @@ use crate::{
     level_instantiation::on_spawn::{player, Npc, Player},
     movement::character_controller::Walk,
     util::math_trait_ext::{F32Ext, Vec3Ext},
-    GameState, GameSystemSet,
+    GameSystemSet,
 };
 #[cfg(feature = "dev")]
 use anyhow::Context;
@@ -40,12 +40,7 @@ pub(super) fn plugin(app: &mut App) {
         max_edge_length: 100,
         max_tile_generation_tasks: None,
     }))
-    .add_systems(
-        Update,
-        query_mesh
-            .in_set(GameSystemSet::Navigation)
-            .run_if(in_state(GameState::Playing)),
-    );
+    .add_systems(Update, query_mesh.in_set(GameSystemSet::Navigation));
     #[cfg(feature = "dev")]
     app.add_plugins(OxidizedNavigationDebugDrawPlugin)
         .add_systems(Update, draw_navmesh);

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -8,7 +8,6 @@ use bevy::prelude::*;
 use bevy_hanabi::prelude::*;
 use bevy_mod_sysfail::prelude::*;
 use bevy_tnua::prelude::*;
-use bevy_xpbd_3d::PhysicsSet;
 pub(crate) use creation::*;
 
 mod creation;
@@ -19,9 +18,7 @@ pub(super) fn plugin(app: &mut App) {
         .add_plugins(HanabiPlugin)
         .add_systems(
             Update,
-            play_sprinting_effect
-                .run_if(in_state(GameState::Playing))
-                .after(PhysicsSet::Sync),
+            play_sprinting_effect.run_if(in_state(GameState::Playing)),
         );
 }
 

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -1,12 +1,11 @@
 use crate::{
     file_system_interaction::config::GameConfig,
     level_instantiation::on_spawn::Player,
-    util::math_trait_ext::{F32Ext, Vec3Ext},
+    util::{F32Ext, Vec3Ext},
     GameState,
 };
 use bevy::prelude::*;
 use bevy_hanabi::prelude::*;
-use bevy_mod_sysfail::prelude::*;
 use bevy_tnua::prelude::*;
 pub(crate) use creation::*;
 
@@ -26,7 +25,6 @@ pub(super) fn plugin(app: &mut App) {
 #[reflect(Component)]
 struct SprintingParticle;
 
-#[sysfail(Log<anyhow::Error, Error>)]
 fn play_sprinting_effect(
     with_player: Query<&TnuaController, With<Player>>,
     mut with_particle: Query<&mut EffectSpawner, With<SprintingParticle>>,

--- a/src/player_control/actions.rs
+++ b/src/player_control/actions.rs
@@ -1,4 +1,4 @@
-use crate::util::criteria::is_frozen;
+use crate::util::is_frozen;
 use bevy::prelude::*;
 use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::{axislike::DualAxisData, prelude::*};

--- a/src/player_control/camera.rs
+++ b/src/player_control/camera.rs
@@ -1,4 +1,3 @@
-use crate::level_instantiation::on_spawn::Player;
 use crate::GameSystemSet;
 use crate::{
     player_control::camera::{
@@ -63,13 +62,16 @@ pub(super) fn plugin(app: &mut App) {
         .add_systems(Update, Dolly::<IngameCamera>::update_active)
         .add_systems(Startup, spawn_ui_camera)
         .add_systems(OnEnter(GameState::Playing), despawn_ui_camera)
-        .add_systems(Update, grab_cursor.run_if(in_state(GameState::Playing)))
         .add_systems(
             Update,
-            (update_kind, update_drivers, set_camera_focus, update_rig)
+            (
+                grab_cursor,
+                update_kind,
+                update_drivers,
+                set_camera_focus,
+                update_rig,
+            )
                 .chain()
-                .in_set(GameSystemSet::CameraUpdate)
-                .run_if(in_state(GameState::Playing))
-                .run_if(any_with_component::<Player>),
+                .in_set(GameSystemSet::CameraUpdate),
         );
 }

--- a/src/player_control/camera.rs
+++ b/src/player_control/camera.rs
@@ -1,4 +1,5 @@
 use crate::level_instantiation::on_spawn::Player;
+use crate::GameSystemSet;
 use crate::{
     player_control::camera::{
         cursor::grab_cursor,
@@ -9,11 +10,8 @@ use crate::{
     GameState,
 };
 use bevy::prelude::*;
-use bevy::transform::TransformSystem;
 use bevy_atmosphere::prelude::AtmospherePlugin;
 use bevy_dolly::prelude::Dolly;
-use bevy_xpbd_3d::PhysicsSet;
-use bevy_yarnspinner_example_dialogue_view::ExampleYarnSpinnerDialogueViewSystemSet;
 pub(crate) use cursor::ForceCursorGrabMode;
 use serde::{Deserialize, Serialize};
 use ui::*;
@@ -68,20 +66,10 @@ pub(super) fn plugin(app: &mut App) {
         .add_systems(Update, grab_cursor.run_if(in_state(GameState::Playing)))
         .add_systems(
             Update,
-            (
-                update_kind,
-                update_drivers,
-                set_camera_focus.after(ExampleYarnSpinnerDialogueViewSystemSet),
-                update_rig,
-            )
+            (update_kind, update_drivers, set_camera_focus, update_rig)
                 .chain()
-                .in_set(CameraUpdateSystemSet)
-                .after(PhysicsSet::Sync)
-                .before(TransformSystem::TransformPropagate)
+                .in_set(GameSystemSet::CameraUpdate)
                 .run_if(in_state(GameState::Playing))
                 .run_if(any_with_component::<Player>),
         );
 }
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub(super) struct CameraUpdateSystemSet;

--- a/src/player_control/camera/cursor.rs
+++ b/src/player_control/camera/cursor.rs
@@ -1,26 +1,20 @@
 use crate::player_control::actions::ActionsFrozen;
-use anyhow::Context;
+use crate::util::single_mut;
 use bevy::{
     prelude::*,
     window::{CursorGrabMode, PrimaryWindow},
 };
-use bevy_mod_sysfail::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Resource, Serialize, Deserialize, Default)]
 pub(crate) struct ForceCursorGrabMode(pub(crate) Option<CursorGrabMode>);
 
-#[sysfail(Log<anyhow::Error, Error>)]
 pub(super) fn grab_cursor(
     mut primary_windows: Query<&mut Window, With<PrimaryWindow>>,
     actions_frozen: Res<ActionsFrozen>,
     force_cursor_grab: Res<ForceCursorGrabMode>,
 ) {
-    #[cfg(feature = "tracing")]
-    let _span = info_span!("cursor_grab_system").entered();
-    let mut window = primary_windows
-        .get_single_mut()
-        .context("Failed to get primary window")?;
+    let mut window = single_mut!(primary_windows);
     let cursor = &mut window.cursor;
     if let Some(mode) = force_cursor_grab.0 {
         cursor.grab_mode = mode;

--- a/src/player_control/camera/focus.rs
+++ b/src/player_control/camera/focus.rs
@@ -1,13 +1,12 @@
+use crate::util::{single, single_mut};
 use crate::{
     level_instantiation::on_spawn::{player, Player},
     player_control::camera::IngameCamera,
     world_interaction::dialog::CurrentDialogTarget,
 };
 use bevy::prelude::*;
-use bevy_mod_sysfail::prelude::*;
 use bevy_yarnspinner::events::DialogueCompleteEvent;
 
-#[sysfail(Log<anyhow::Error, Error>)]
 pub(super) fn set_camera_focus(
     mut camera_query: Query<&mut IngameCamera>,
     player_query: Query<&Transform, With<Player>>,
@@ -15,14 +14,14 @@ pub(super) fn set_camera_focus(
     dialog_target: Res<CurrentDialogTarget>,
     mut dialogue_complete_event: EventReader<DialogueCompleteEvent>,
 ) {
-    for mut camera in camera_query.iter_mut() {
-        let player_transform = player_query.get_single()?;
-        if let Some(dialog_target) = dialog_target.0 {
-            let dialog_target_transform = dialog_targets.get(dialog_target)?;
-            camera.secondary_target = Some(dialog_target_transform.translation);
-        }
-        camera.target = player_transform.translation + Vec3::Y * player::HEIGHT / 2.;
+    let mut camera = single_mut!(camera_query);
+    let player_transform = single!(player_query);
+    if let Some(dialog_target) = dialog_target.0 {
+        let dialog_target_transform = dialog_targets.get(dialog_target).unwrap();
+        camera.secondary_target = Some(dialog_target_transform.translation);
     }
+    camera.target = player_transform.translation + Vec3::Y * player::HEIGHT / 2.;
+
     for _event in dialogue_complete_event.read() {
         for mut camera in camera_query.iter_mut() {
             camera.secondary_target = None;

--- a/src/player_control/camera/rig.rs
+++ b/src/player_control/camera/rig.rs
@@ -7,19 +7,17 @@ use crate::{
             IngameCamera, IngameCameraKind,
         },
     },
-    util::math_trait_ext::Vec2Ext,
+    util::Vec2Ext,
 };
 
 use crate::player_control::actions::ActionsFrozen;
 use bevy::prelude::*;
 use bevy_dolly::prelude::*;
-use bevy_mod_sysfail::prelude::*;
 use bevy_xpbd_3d::prelude::SpatialQuery;
 use leafwing_input_manager::prelude::ActionState;
 
 mod arm;
 
-#[sysfail(Log<anyhow::Error, Error>)]
 pub(super) fn update_rig(
     time: Res<Time<Virtual>>,
     mut camera_query: Query<(

--- a/src/player_control/camera/rig/arm.rs
+++ b/src/player_control/camera/rig/arm.rs
@@ -2,7 +2,6 @@ use crate::{
     file_system_interaction::config::GameConfig,
     movement::physics::CollisionLayer,
     player_control::camera::{IngameCamera, IngameCameraKind},
-    util::smoothness_to_lerp_factor,
 };
 use bevy::prelude::*;
 use bevy_dolly::prelude::*;
@@ -105,4 +104,10 @@ fn get_distance_such_that_min_distance_from_collision_is_ensured(
     let angle = direction.angle_between(-hit.normal);
     let hypotenuse = adjacent_side / angle.cos();
     hit.time_of_impact - hypotenuse
+}
+
+/// Taken from https://github.com/h3r2tic/dolly/blob/main/src/util.rs#L34
+fn smoothness_to_lerp_factor(smoothness: f32, dt: f32) -> f32 {
+    const SMOOTHNESS_MULTIPLIER: f32 = 8.0;
+    1.0 - (-SMOOTHNESS_MULTIPLIER * dt / smoothness.max(1e-5)).exp()
 }

--- a/src/player_control/camera/rig/arm.rs
+++ b/src/player_control/camera/rig/arm.rs
@@ -106,7 +106,7 @@ fn get_distance_such_that_min_distance_from_collision_is_ensured(
     hit.time_of_impact - hypotenuse
 }
 
-/// Taken from https://github.com/h3r2tic/dolly/blob/main/src/util.rs#L34
+/// Taken from <https://github.com/h3r2tic/dolly/blob/main/src/util.rs#L34>
 fn smoothness_to_lerp_factor(smoothness: f32, dt: f32) -> f32 {
     const SMOOTHNESS_MULTIPLIER: f32 = 8.0;
     1.0 - (-SMOOTHNESS_MULTIPLIER * dt / smoothness.max(1e-5)).exp()

--- a/src/player_control/player_embodiment.rs
+++ b/src/player_control/player_embodiment.rs
@@ -3,8 +3,9 @@ use crate::{
     movement::character_controller::*,
     player_control::{
         actions::{DualAxisDataExt, PlayerAction},
-        camera::{CameraUpdateSystemSet, IngameCamera, IngameCameraKind},
+        camera::{IngameCamera, IngameCameraKind},
     },
+    GameSystemSet,
 };
 
 use crate::{
@@ -16,7 +17,6 @@ use bevy::prelude::*;
 use bevy_kira_audio::AudioInstance;
 use bevy_mod_sysfail::prelude::*;
 use bevy_tnua::{builtins::TnuaBuiltinWalk, controller::TnuaController};
-use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::prelude::ActionState;
 
 /// This plugin handles everything that has to do with the player's physical representation in the world.
@@ -34,9 +34,7 @@ pub(super) fn plugin(app: &mut App) {
                 handle_camera_kind,
             )
                 .chain()
-                .before(CameraUpdateSystemSet)
-                .before(GeneralMovementSystemSet)
-                .after(InputManagerSystem::ManualControl)
+                .in_set(GameSystemSet::PlayerEmbodiment)
                 .run_if(in_state(GameState::Playing)),
         );
 }

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -1,28 +1,48 @@
+use crate::GameState;
 use bevy::prelude::*;
 use bevy_dolly::prelude::DollyUpdateSet;
 use bevy_gltf_blueprints::GltfBlueprintsSet;
+use bevy_yarnspinner::prelude::YarnSpinnerSystemSet;
 use bevy_yarnspinner_example_dialogue_view::ExampleYarnSpinnerDialogueViewSystemSet;
 
 pub(super) fn plugin(app: &mut App) {
     app.configure_sets(
         Update,
         (
-                GltfBlueprintsSet::AfterSpawn,
-                GameSystemSet::ColliderSpawn,
-                GameSystemSet::UpdateInteractionOpportunities,
-                GameSystemSet::Navigation,
-                GameSystemSet::PlayerEmbodiment,
-                GameSystemSet::GeneralMovement,
-                GameSystemSet::PlayAnimation,
-                GameSystemSet::Dialog,
-                ExampleYarnSpinnerDialogueViewSystemSet,
-                GameSystemSet::CameraUpdate,
-                DollyUpdateSet,
+            GltfBlueprintsSet::AfterSpawn,
+            YarnSpinnerSystemSet,
+            GameSystemSet::ColliderSpawn,
+            GameSystemSet::Navigation,
+            GameSystemSet::PlayerEmbodiment,
+            GameSystemSet::GeneralMovement,
+            GameSystemSet::PlayAnimation,
+            GameSystemSet::UpdateInteractionOpportunities,
+            GameSystemSet::Dialog,
+            ExampleYarnSpinnerDialogueViewSystemSet,
+            GameSystemSet::CameraUpdate,
+            DollyUpdateSet,
         )
             .chain(),
+    )
+    .configure_sets(
+        Update,
+        (
+            GameSystemSet::ColliderSpawn,
+            GameSystemSet::UpdateInteractionOpportunities,
+            GameSystemSet::Navigation,
+            GameSystemSet::PlayerEmbodiment,
+            GameSystemSet::GeneralMovement,
+            GameSystemSet::PlayAnimation,
+            GameSystemSet::Dialog,
+            GameSystemSet::CameraUpdate,
+        )
+            .run_if(in_state(GameState::Playing)),
     );
 }
 
+/// Used for ordering systems across Foxtrot.
+/// Note that the order of items of this enum is not necessarily the order of execution.
+/// Look at [`crate::system_set::plugin`] for the actual order used.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub(crate) enum GameSystemSet {
     /// Goes through entities tagged with `Collider` in Blender

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -1,0 +1,58 @@
+use bevy::prelude::*;
+use bevy_dolly::prelude::DollyUpdateSet;
+use bevy_gltf_blueprints::GltfBlueprintsSet;
+use bevy_yarnspinner_example_dialogue_view::ExampleYarnSpinnerDialogueViewSystemSet;
+
+pub(super) fn plugin(app: &mut App) {
+    app.configure_sets(
+        Update,
+        (
+            (
+                GltfBlueprintsSet::AfterSpawn,
+                GameSystemSet::ColliderSpawn,
+                GameSystemSet::Navigation,
+                GameSystemSet::PlayerEmbodiment,
+                GameSystemSet::GeneralMovement,
+                GameSystemSet::PrepareAnimationState,
+            )
+                .chain(),
+            (
+                GameSystemSet::UpdateAnimationState,
+                GameSystemSet::PlayAnimation,
+                ExampleYarnSpinnerDialogueViewSystemSet,
+                GameSystemSet::CameraUpdate,
+                DollyUpdateSet,
+                GameSystemSet::UpdateInteractionOpportunities,
+            )
+                .chain(),
+        )
+            .chain(),
+    );
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+pub(crate) enum GameSystemSet {
+    /// - Goes through entities tagged with [`ColliderConstructor`](crate::physics::ColliderConstructor) in Blender
+    /// - Inserts a proper XPBD collider
+    /// - Inserts [`SensorLinks`](crate::physics::SensorLinks) on all [`RigidBody`](bevy_xpbd_3d::components::RigidBody)s
+    /// - Links sensor colliders to their closest [`SensorLinks`](crate::physics::SensorLinks) up the hierarchy
+    ColliderSpawn,
+    /// Run path finding
+    Navigation,
+    /// Update interaction opportunities with the environment
+    UpdateInteractionOpportunities,
+    /// Handle player input
+    PlayerEmbodiment,
+    /// Handle movement for character controllers
+    GeneralMovement,
+    /// Prepare the exclusive animation state for the current frame
+    PrepareAnimationState,
+    /// Update the animation state according to this frame's events since [`GameSystemSet::PrepareAnimationState`]
+    UpdateAnimationState,
+    /// Play animations
+    PlayAnimation,
+    /// Update the camera transform
+    CameraUpdate,
+    /// Interacts with Yarn Spinner for dialog logic
+    Dialog,
+}

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -7,24 +7,17 @@ pub(super) fn plugin(app: &mut App) {
     app.configure_sets(
         Update,
         (
-            (
                 GltfBlueprintsSet::AfterSpawn,
                 GameSystemSet::ColliderSpawn,
+                GameSystemSet::UpdateInteractionOpportunities,
                 GameSystemSet::Navigation,
                 GameSystemSet::PlayerEmbodiment,
                 GameSystemSet::GeneralMovement,
-                GameSystemSet::PrepareAnimationState,
-            )
-                .chain(),
-            (
-                GameSystemSet::UpdateAnimationState,
                 GameSystemSet::PlayAnimation,
+                GameSystemSet::Dialog,
                 ExampleYarnSpinnerDialogueViewSystemSet,
                 GameSystemSet::CameraUpdate,
                 DollyUpdateSet,
-                GameSystemSet::UpdateInteractionOpportunities,
-            )
-                .chain(),
         )
             .chain(),
     );
@@ -32,10 +25,8 @@ pub(super) fn plugin(app: &mut App) {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub(crate) enum GameSystemSet {
-    /// - Goes through entities tagged with [`ColliderConstructor`](crate::physics::ColliderConstructor) in Blender
-    /// - Inserts a proper XPBD collider
-    /// - Inserts [`SensorLinks`](crate::physics::SensorLinks) on all [`RigidBody`](bevy_xpbd_3d::components::RigidBody)s
-    /// - Links sensor colliders to their closest [`SensorLinks`](crate::physics::SensorLinks) up the hierarchy
+    /// Goes through entities tagged with `Collider` in Blender
+    /// and inserts a proper XPBD collider
     ColliderSpawn,
     /// Run path finding
     Navigation,
@@ -45,10 +36,6 @@ pub(crate) enum GameSystemSet {
     PlayerEmbodiment,
     /// Handle movement for character controllers
     GeneralMovement,
-    /// Prepare the exclusive animation state for the current frame
-    PrepareAnimationState,
-    /// Update the animation state according to this frame's events since [`GameSystemSet::PrepareAnimationState`]
-    UpdateAnimationState,
     /// Play animations
     PlayAnimation,
     /// Update the camera transform

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,2 +1,27 @@
 pub(crate) mod criteria;
 pub(crate) mod math_trait_ext;
+
+macro_rules! single {
+    ($query:expr) => {
+        match $query.get_single() {
+            Ok(q) => q,
+            _ => {
+                return;
+            }
+        }
+    };
+}
+
+macro_rules! single_mut {
+    ($query:expr) => {
+        match $query.get_single_mut() {
+            Ok(q) => q,
+            _ => {
+                return;
+            }
+        }
+    };
+}
+
+pub(crate) use single;
+pub(crate) use single_mut;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
-pub(crate) mod criteria;
-pub(crate) mod math_trait_ext;
+mod criteria;
+mod math_trait_ext;
+mod pipe;
+
+pub(crate) use self::{criteria::*, math_trait_ext::*, pipe::*};
 
 macro_rules! single {
     ($query:expr) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,2 @@
 pub(crate) mod criteria;
 pub(crate) mod math_trait_ext;
-
-pub(crate) fn smoothness_to_lerp_factor(smoothness: f32, dt: f32) -> f32 {
-    // Taken from https://github.com/h3r2tic/dolly/blob/main/src/util.rs#L34
-    const SMOOTHNESS_MULTIPLIER: f32 = 8.0;
-    1.0 - (-SMOOTHNESS_MULTIPLIER * dt / smoothness.max(1e-5)).exp()
-}

--- a/src/util/pipe.rs
+++ b/src/util/pipe.rs
@@ -1,0 +1,8 @@
+use bevy::log::error;
+use bevy::prelude::*;
+
+pub(crate) fn error(In(result): In<Result<(), anyhow::Error>>) {
+    if let Err(err) = result {
+        error!("Error: {err:?}")
+    }
+}

--- a/src/world_interaction/dialog.rs
+++ b/src/world_interaction/dialog.rs
@@ -16,9 +16,9 @@ pub(super) fn plugin(app: &mut App) {
         Update,
         (
             spawn_dialogue_runner.run_if(resource_added::<YarnProject>),
-            unfreeze_after_dialog,
+            unfreeze_after_dialog.in_set(GameSystemSet::Dialog),
         )
-            .in_set(GameSystemSet::Dialog),
+            .chain(),
     )
     .init_resource::<CurrentDialogTarget>()
     .register_type::<YarnNode>()

--- a/src/world_interaction/dialog.rs
+++ b/src/world_interaction/dialog.rs
@@ -1,9 +1,9 @@
 use crate::player_control::actions::ActionsFrozen;
+use crate::GameSystemSet;
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;
 use bevy_yarnspinner::{events::DialogueCompleteEvent, prelude::*};
 use bevy_yarnspinner_example_dialogue_view::prelude::*;
-use leafwing_input_manager::plugin::InputManagerSystem;
 use serde::{Deserialize, Serialize};
 
 pub(super) fn plugin(app: &mut App) {
@@ -16,9 +16,9 @@ pub(super) fn plugin(app: &mut App) {
         Update,
         (
             spawn_dialogue_runner.run_if(resource_added::<YarnProject>),
-            unfreeze_after_dialog.after(InputManagerSystem::ManualControl),
+            unfreeze_after_dialog,
         )
-            .after(ExampleYarnSpinnerDialogueViewSystemSet),
+            .in_set(GameSystemSet::Dialog),
     )
     .init_resource::<CurrentDialogTarget>()
     .register_type::<YarnNode>()

--- a/src/world_interaction/interaction_ui.rs
+++ b/src/world_interaction/interaction_ui.rs
@@ -6,7 +6,7 @@ use crate::{
         actions::{ActionsFrozen, PlayerAction},
         camera::{IngameCamera, IngameCameraKind},
     },
-    util::criteria::is_frozen,
+    util::is_frozen,
     world_interaction::dialog::{CurrentDialogTarget, YarnNode},
 };
 use bevy::{prelude::*, window::PrimaryWindow};

--- a/src/world_interaction/interaction_ui.rs
+++ b/src/world_interaction/interaction_ui.rs
@@ -1,3 +1,4 @@
+use crate::system_set::GameSystemSet;
 use crate::{
     level_instantiation::on_spawn::Player,
     player_control::{
@@ -8,7 +9,7 @@ use crate::{
     world_interaction::dialog::{CurrentDialogTarget, YarnNode},
     GameState,
 };
-use bevy::{prelude::*, transform::TransformSystem::TransformPropagate, window::PrimaryWindow};
+use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 use bevy_mod_sysfail::prelude::*;
 use bevy_xpbd_3d::prelude::*;
@@ -23,12 +24,8 @@ pub(super) fn plugin(app: &mut App) {
         .init_resource::<InteractionOpportunity>()
         .add_systems(
             Update,
-            (
-                update_interaction_opportunities
-                    .after(PhysicsSet::Sync)
-                    .after(TransformPropagate),
-                display_interaction_prompt,
-            )
+            (update_interaction_opportunities, display_interaction_prompt)
+                .in_set(GameSystemSet::UpdateInteractionOpportunities)
                 .chain()
                 .run_if(
                     not(is_frozen)


### PR DESCRIPTION
- Move all system sets into one enum: `GameSystemSet`
- Rework some ordering
- Eliminate all instances of `.after` and `.before`
	- This makes our use-case for `bevy_mod_sysfail` obsolete -> remove it
- Remove system set ordering across schedules. This had no effect and will probably result in a Bevy warning in the future.