### PR TITLE
fix character capsule size issue

### DIFF
--- a/src/movement/character_controller/components.rs
+++ b/src/movement/character_controller/components.rs
@@ -2,7 +2,7 @@ use crate::movement::{character_controller::AnimationState, physics::CollisionLa
 use bevy::prelude::*;
 use bevy_tnua::{prelude::*, TnuaAnimatingState};
 use bevy_tnua_xpbd3d::*;
-use bevy_xpbd_3d::prelude::*;
+use bevy_xpbd_3d::{parry::shape::SharedShape, prelude::*};
 use serde::{Deserialize, Serialize};
 
 pub(super) fn plugin(app: &mut App) {
@@ -30,8 +30,7 @@ impl CharacterControllerBundle {
             walking: default(),
             sprinting: default(),
             jumping: default(),
-            collider: bevy_xpbd_3d::parry::shape::SharedShape::capsule_z(height, radius * scale_y)
-                .into(),
+            collider: SharedShape::capsule_z(height, radius * scale_y).into(),
             rigid_body: RigidBody::Dynamic,
             locked_axes: LockedAxes::new().lock_rotation_x().lock_rotation_z(),
             collision_layers: CollisionLayers::new(
@@ -44,11 +43,7 @@ impl CharacterControllerBundle {
                 ],
             ),
             tnua_sensor_shape: TnuaXpbd3dSensorShape(
-                bevy_xpbd_3d::parry::shape::SharedShape::capsule_z(
-                    height * 0.95,
-                    radius * scale_y * 0.95,
-                )
-                .into(),
+                SharedShape::capsule_z(height * 0.95, radius * scale_y * 0.95).into(),
             ),
             tnua_controller: default(),
             float_height: FloatHeight(radius * scale_y),

--- a/src/movement/character_controller/components.rs
+++ b/src/movement/character_controller/components.rs
@@ -30,7 +30,8 @@ impl CharacterControllerBundle {
             walking: default(),
             sprinting: default(),
             jumping: default(),
-            collider: Collider::capsule(height, radius),
+            collider: bevy_xpbd_3d::parry::shape::SharedShape::capsule_z(height, radius * scale_y)
+                .into(),
             rigid_body: RigidBody::Dynamic,
             locked_axes: LockedAxes::new().lock_rotation_x().lock_rotation_z(),
             collision_layers: CollisionLayers::new(
@@ -42,12 +43,15 @@ impl CharacterControllerBundle {
                     CollisionLayer::Sensor,
                 ],
             ),
-            tnua_sensor_shape: TnuaXpbd3dSensorShape(Collider::capsule(
-                height * 0.95,
-                radius * 0.95,
-            )),
+            tnua_sensor_shape: TnuaXpbd3dSensorShape(
+                bevy_xpbd_3d::parry::shape::SharedShape::capsule_z(
+                    height * 0.95,
+                    radius * scale_y * 0.95,
+                )
+                .into(),
+            ),
             tnua_controller: default(),
-            float_height: FloatHeight((height / 2. + radius) * scale_y),
+            float_height: FloatHeight(radius * scale_y),
             animation_state: default(),
         }
     }


### PR DESCRIPTION
In project Foxtrot, the capsule of the fox should be in fact a lying down cylinder.
Because its an quadruped animal.

So in fact in the code the height is the length of the fox, and the radius
is a half of the height of the fox.

Also, the radius of the capsule need to be multiplied by the scale_y.

There's no visual changes in the game.
Open "Foxtrot Dev" window and toggle Colliders rendering on to see the difference.

Also if the pull was merged, I assume that "HEIGHT" should be renamed to "LENGTH" later on.