### PR TITLE
Fix log filter concatenation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> AppExit {
             .set(LogPlugin {
                 filter: format!(
                     concat!(
-                        "{default}",
+                        "{default},",
                         "symphonia_bundle_mp3::demuxer=warn,",
                         "symphonia_format_caf::demuxer=warn,",
                         "symphonia_format_isompf4::demuxer=warn,",


### PR DESCRIPTION
`bevy::log::DEFAULT_FILTER` does not contain a trailing comma.